### PR TITLE
Add Control prompt to building template

### DIFF
--- a/scenes/components/outpost/BuildingTemplate.cs
+++ b/scenes/components/outpost/BuildingTemplate.cs
@@ -5,13 +5,22 @@ public partial class BuildingTemplate : Node2D {
 
 	[Export] public PackedScene OverlayScene { get; set; }
 	[Export] public Texture2D TextureHouse { get; set; }
+	[Export] public Texture2D TextureIcon { get; set; }
+	[Export] public string DisplayName { get; set; } = "Building";
+	[Export] public Vector2 PromptOffset { get; set; } = new(0, -108);
 
 	private Sprite2D _houseSprite;
+	private Control _prompt;
+	private TextureRect _promptIcon;
+	private Label _promptLabel;
 	private Area2D _area;
 	private ulong _lastOpenTimeMs;
 
 	public override void _Ready() {
 		_houseSprite = GetNodeOrNull<Sprite2D>("SpriteHouse");
+		_prompt = GetNodeOrNull<Control>("ClickPanel");
+		_promptIcon = GetNodeOrNull<TextureRect>("ClickPanel/Icon");
+		_promptLabel = GetNodeOrNull<Label>("ClickPanel/LabelPanel/Label");
 		_area = GetNodeOrNull<Area2D>("Area2D");
 
 		ApplyExportedValues();
@@ -27,6 +36,25 @@ public partial class BuildingTemplate : Node2D {
 	private void ApplyExportedValues() {
 		if (_houseSprite != null && TextureHouse != null)
 			_houseSprite.Texture = TextureHouse;
+
+		if (_promptIcon != null && TextureIcon != null)
+			_promptIcon.Texture = TextureIcon;
+
+		if (_promptLabel != null)
+			_promptLabel.Text = DisplayName;
+
+		UpdatePromptPosition();
+	}
+
+	public override void _Process(double delta) {
+		UpdatePromptPosition();
+	}
+
+	private void UpdatePromptPosition() {
+		if (_prompt == null)
+			return;
+
+		_prompt.GlobalPosition = GlobalPosition + PromptOffset - new Vector2(_prompt.Size.X * 0.5f, 0);
 	}
 
 	private void OnAreaInputEvent(Node viewport, InputEvent @event, long shapeIdx) {

--- a/scenes/components/outpost/buildingTemplate.tscn
+++ b/scenes/components/outpost/buildingTemplate.tscn
@@ -6,6 +6,17 @@
 [sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_13jms"]
 size = Vector2(64, 64)
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_label_panel"]
+bg_color = Color(0.08, 0.07, 0.06, 0.82)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+content_margin_left = 8.0
+content_margin_top = 3.0
+content_margin_right = 8.0
+content_margin_bottom = 3.0
+
 [sub_resource type="CircleShape2D" id="CircleShape2D_13jms"]
 radius = 61.03278
 
@@ -16,9 +27,45 @@ TextureHouse = ExtResource("1_8rcmu")
 [node name="SpriteHouse" type="Sprite2D" parent="." unique_id=333691828]
 texture = ExtResource("1_8rcmu")
 
-[node name="Sprite2D" type="Sprite2D" parent="." unique_id=735441159]
-position = Vector2(0, -56)
+[node name="ClickPanel" type="Control" parent="." unique_id=735441159]
+layout_mode = 3
+anchors_preset = 0
+offset_left = -48.0
+offset_top = -108.0
+offset_right = 48.0
+offset_bottom = -28.0
+mouse_filter = 2
+
+[node name="Icon" type="TextureRect" parent="ClickPanel" unique_id=790543333]
+layout_mode = 1
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -24.0
+offset_right = 24.0
+offset_bottom = 48.0
+grow_horizontal = 2
+mouse_filter = 2
 texture = SubResource("PlaceholderTexture2D_13jms")
+expand_mode = 1
+stretch_mode = 5
+
+[node name="LabelPanel" type="PanelContainer" parent="ClickPanel" unique_id=179570743]
+layout_mode = 1
+anchors_preset = 10
+anchor_right = 1.0
+offset_top = 52.0
+offset_bottom = 80.0
+grow_horizontal = 2
+mouse_filter = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_label_panel")
+
+[node name="Label" type="Label" parent="ClickPanel/LabelPanel" unique_id=429572716]
+layout_mode = 2
+mouse_filter = 2
+text = "Building"
+horizontal_alignment = 1
+vertical_alignment = 1
 
 [node name="Area2D" type="Area2D" parent="." unique_id=380661012]
 collision_layer = 128


### PR DESCRIPTION
## Summary
- Replace the building prompt Sprite2D with a Control-based prompt using TextureRect and Label.
- Add a panel-backed label for readability while keeping Area2D input handling on the world object.

## Validation
- dotnet build SinglePlayerRogueliteV2.csproj