### PR TITLE
Add saved outpost building generation

### DIFF
--- a/autoload/save/data/RunData.cs
+++ b/autoload/save/data/RunData.cs
@@ -1,4 +1,5 @@
 using Godot;
+using Godot.Collections;
 using MyTypes;
 
 namespace SaveData {
@@ -9,6 +10,7 @@ namespace SaveData {
 		[Export] public PlayerData PlayerData { get; set; } = new PlayerData();
 		[Export] public Contract CurrentContract { get; set; } = null;
 		[Export] public InventoryData InventoryData { get; set; } = new InventoryData();
+		[Export] public Array<BuildingData> OutpostBuildings { get; set; }
 		[Export] public int ContractsCompleted { get; set; } = 0;
 		[Export] public int Gold { get; set; } = 100;
 		public override string ToString() {
@@ -18,6 +20,7 @@ namespace SaveData {
 				+ $"  PlayerData={FormatResource(PlayerData)}\n"
 				+ $"  CurrentContract={FormatResource(CurrentContract)}\n"
 				+ $"  InventoryData={FormatResource(InventoryData)}\n"
+				+ $"  OutpostBuildings={OutpostBuildings?.Count ?? 0}\n"
 				+ $"  ContractsCompleted={ContractsCompleted}\n"
 				+ $"  Gold={Gold}";
 		}

--- a/docs/AI-Summary/Outpost-System.md
+++ b/docs/AI-Summary/Outpost-System.md
@@ -1,0 +1,117 @@
+# Outpost System Memory
+
+Internal AI memory for the outpost and building system. Keep this aligned with current code and intended direction.
+
+## Core Intent
+
+The outpost is the between-run hub. Some buildings are permanent, while other building slots are generated and saved as part of the current run.
+
+Important design split:
+
+- `Node2D` is used for world placement, collision, and game-object logic.
+- `Control` is used for UI such as building prompts, overlay buttons, owner portraits, and dialogue text.
+- Do not build non-trivial UI from `Node2D` unless it is intentionally very simple world art.
+
+## Important Scenes And Scripts
+
+- `scenes/main/outpost/Outpost.tscn`: main outpost scene.
+- `scenes/main/outpost/OutpostBuildings.cs`: script on `World/OutpostBuildings`; owns random/generated outpost building generation.
+- `scenes/components/outpost/buildingTemplate.tscn`: reusable in-world building scene.
+- `scenes/components/outpost/BuildingTemplate.cs`: click/touch handler for a building; always opens `BuildingOverlay.tscn`.
+- `scenes/components/outpost/BuildingData.cs`: resource that owns building display data and overlay generation logic.
+- `scenes/overlays/building/BuildingOverlay.tscn`: full-screen building overlay.
+- `scenes/overlays/building/BuildingOverlay.cs`: intentionally thin; forwards `Update(BuildingData)` to the resource.
+- `scenes/overlays/building/BuildingOverlayButtonData.cs`: resource for one building overlay button.
+
+## Save Flow
+
+Generated outpost buildings are saved inside `RunData`:
+
+```csharp
+[Export] public Array<BuildingData> OutpostBuildings { get; set; }
+```
+
+Current first-entry behavior:
+
+- `RunData.OutpostBuildings == null` means the player has not had this outpost generated yet.
+- `OutpostBuildings._Ready()` checks this value through `SaveNode.Get().RunData.OutpostBuildings`.
+- If null, it generates mock data for now, assigns it to `RunData.OutpostBuildings`, and calls `SaveNode.SaveRunData()`.
+- On later visits, saved `BuildingData` is reused.
+
+Be careful changing exported names on `BuildingData` because saved `.tres` run data can serialize these fields.
+
+## Current Outpost Layout
+
+In `Outpost.tscn`:
+
+- `World/OutpostBuildings` owns randomized/generated slots.
+- Generated slots are named `RandomSlot1`, `RandomSlot2`, `RandomSlot3`.
+- Permanent outpost buildings currently include `Contract` and `Inn` as direct children under `World`.
+- `Contract` and `Inn` intentionally instance `buildingTemplate.tscn` because they should always exist in an outpost.
+- Random slots are empty `Node2D` placeholders; `OutpostBuildings.cs` instantiates `buildingTemplate.tscn` into them.
+
+## BuildingData Resource
+
+`BuildingData` is the central data/resource object for a building. It should contain the information needed to generate the building overlay and should be suitable for saving in `RunData`.
+
+Current exported data includes:
+
+- `LabelName`: building title, such as `Inn`, `Contract`, or `Blacksmith`.
+- `Description`: short descriptive text for `PanelBuilding`.
+- `OwnerTexture`: portrait/storekeeper/building-owner image for the overlay homepage.
+- `OwnerText`: rich text dialogue shown in the center homepage area.
+- `OwnerTextRevealSeconds`: duration for RPG-style dialogue reveal.
+- `BuildingTexture`: in-world building sprite texture.
+- `OverlayButtons`: array of `BuildingOverlayButtonData` resources.
+
+`BuildingData.Generate(BuildingOverlay overlay)` owns the overlay regeneration. Keep the overlay construction logic here unless there is a strong reason to move it.
+
+## Building Overlay
+
+`BuildingOverlay` should stay simple. Its public flow is:
+
+```csharp
+public void Update(BuildingData buildingData) {
+    buildingData.Generate(this);
+}
+```
+
+The overlay homepage currently has:
+
+- Owner/building image on the left.
+- Rich text dialogue in the center.
+- Dialogue reveal animation using `RichTextLabel.VisibleRatio` from `0` to `1`.
+- Bottom action buttons generated from `BuildingData.OverlayButtons`.
+
+`BuildingOverlayButtonData` currently has:
+
+- `IconPath`: path to an icon resource; empty path falls back to placeholder icon.
+- `LabelName`: button text.
+- `PathController`: packed scene opened when the button is pressed.
+
+## Current Mock Data
+
+`OutpostBuildings.GenerateMockBuildings()` currently creates one mock `Blacksmith` building.
+
+Current placeholder behavior:
+
+- Blacksmith uses generated `PlaceholderTexture2D` for building and owner images.
+- The mock `Forge` button uses an empty icon path so `BuildingData` falls back to a placeholder icon.
+- The mock `Forge` button currently has no `PathController`; pressing it logs a warning.
+
+## Permanent Building Data Files
+
+Permanent building data currently lives in resource files:
+
+- `scenes/components/outpost/inn_building_data.tres`
+- `scenes/components/outpost/contract_building_data.tres`
+
+These are referenced by `Outpost.tscn` on the permanent building template instances.
+
+## Implementation Cautions
+
+- Keep generated building slots separate from permanent buildings.
+- If a building is always present, it can directly instance `buildingTemplate.tscn` in `Outpost.tscn`.
+- If a building is generated/randomized, place only an empty `Node2D` slot in `World/OutpostBuildings` and let `OutpostBuildings.cs` instantiate it.
+- For building UI, prefer data-driven changes in `BuildingData.Generate(...)` over adding more logic to `BuildingOverlay.cs`.
+- Validate C# changes with `dotnet build`, but still run the Godot scene for node path/editor assignment issues.

--- a/docs/AI-Summary/SUMMARY.md
+++ b/docs/AI-Summary/SUMMARY.md
@@ -37,6 +37,7 @@ This folder is for AI assistants to keep project-specific context across coding 
 ## AI Detail File Index
 
 - `docs/AI-Summary/Item-System-Goal.md`: item-system intent, generic dependencies, consumables, condition/durability, ammo, and future extensibility.
+- `docs/AI-Summary/Outpost-System.md`: outpost building generation, `BuildingData`, permanent/random slots, saved run data, and building overlay flow.
 
 ## Godot Setup
 
@@ -96,6 +97,7 @@ This folder is for AI assistants to keep project-specific context across coding 
 ## Core Data Models
 
 - `RunData` tracks current biome, current location, current contract, inventory, completed contracts, gold, and active player data.
+- `RunData.OutpostBuildings` stores generated outpost `BuildingData` resources for the current run; `null` means the outpost has not generated its random buildings yet.
 - `PlayerData` tracks player name, equipped items, and skill data.
 - `MetaData`, `SettingsData`, `InventoryData`, `EquipedItemsData`, `PlayerSkillData`, and store data live under `autoload/save/data/`.
 - Shared enums live in `core/types/Types.cs` under `MyTypes` and `SaveData` namespaces.
@@ -135,7 +137,10 @@ This folder is for AI assistants to keep project-specific context across coding 
 - Main flows currently include start menu, run overview, new character selection, and outpost.
 - `RunOverview` wires continue/new-run/back buttons to outpost, new character select, and start menu scenes.
 - `Outpost.tscn` main overlay buttons are split between `TopUI` and `BottomUI`: `ExitButton` changes back to `StartMenu`, `BtnSettings` opens `SettingsOverlay`, `BtnInventory` opens `InventoryOverlay`, `BtnCharacter` opens `CharacterOverlay`, and `BtnCodex` opens `CodexOverlay`.
-- `BuildingTemplate` opens an exported overlay scene when clicked/touched through its `Area2D`, with a 250ms debounce.
+- `Outpost.tscn` has permanent `Contract` and `Inn` building template instances under `World`, plus generated slots under `World/OutpostBuildings` named `RandomSlot1`, `RandomSlot2`, and `RandomSlot3`.
+- `OutpostBuildings.cs` checks `SaveNode.RunData.OutpostBuildings`, generates mock building data when null, saves it to run data, and instantiates `buildingTemplate.tscn` into random slots.
+- `BuildingTemplate` always opens `BuildingOverlay.tscn` when clicked/touched through its `Area2D`, with a 250ms debounce, and passes its `BuildingData` into the overlay.
+- `BuildingOverlay` should stay thin; `BuildingData.Generate(BuildingOverlay)` owns regenerating title, description, owner portrait, RPG-style rich text dialogue, and bottom action buttons.
 - Panel components display stats, gold, run metadata, location, building information, and player top UI.
 - Design UI for landscape phones first. Prefer big readable labels, generous spacing, and large touch targets over compact PC-style layouts.
 - Many UI scenes rely on exact node paths. When editing `.tscn` structure, update corresponding C# paths.

--- a/scenes/components/outpost/BuildingData.cs
+++ b/scenes/components/outpost/BuildingData.cs
@@ -1,0 +1,86 @@
+using Godot;
+using Godot.Collections;
+
+[GlobalClass]
+public partial class BuildingData : Resource {
+	private readonly Texture2D _fallbackIcon = new PlaceholderTexture2D { Size = new Vector2I(64, 64) };
+
+	[Export] public string LabelName { get; set; } = "Building";
+	[Export(PropertyHint.MultilineText)] public string Description { get; set; } = "";
+	[Export] public Texture2D OwnerTexture { get; set; }
+	[Export(PropertyHint.MultilineText)] public string OwnerText { get; set; } = "Welcome.";
+	[Export] public double OwnerTextRevealSeconds { get; set; } = 1.5;
+	[Export] public Texture2D BuildingTexture { get; set; }
+	[Export] public Array<BuildingOverlayButtonData> OverlayButtons { get; set; } = new();
+
+	public void Generate(BuildingOverlay overlay) {
+		if (overlay == null)
+			return;
+
+		var titleLabel = overlay.GetNodeOrNull<Label>("PanelBuilding/HBoxContainer/Labels/Label");
+		if (titleLabel != null)
+			titleLabel.Text = string.IsNullOrWhiteSpace(LabelName) ? "Building" : LabelName;
+
+		var descriptionLabel = overlay.GetNodeOrNull<Label>("PanelBuilding/HBoxContainer/Labels/Label2");
+		if (descriptionLabel != null)
+			descriptionLabel.Text = Description;
+
+		var ownerTexture = overlay.GetNodeOrNull<TextureRect>("PanelOverlay/CenterContent/OwnerPortrait");
+		if (ownerTexture != null)
+			ownerTexture.Texture = OwnerTexture ?? _fallbackIcon;
+
+		var ownerText = overlay.GetNodeOrNull<RichTextLabel>("PanelOverlay/CenterContent/DialoguePanel/MarginContainer/OwnerText");
+		if (ownerText != null) {
+			ownerText.Text = OwnerText;
+			ownerText.VisibleRatio = 0.0f;
+
+			var tween = overlay.CreateTween();
+			tween.TweenProperty(ownerText, "visible_ratio", 1.0f, Mathf.Max(0.01, OwnerTextRevealSeconds));
+		}
+
+		var bottomUi = overlay.GetNodeOrNull<HBoxContainer>("BottomUI");
+		if (bottomUi == null)
+			return;
+
+		foreach (var child in bottomUi.GetChildren())
+			child.QueueFree();
+
+		foreach (var buttonData in OverlayButtons) {
+			if (buttonData == null)
+				continue;
+
+			bottomUi.AddChild(CreateButton(buttonData));
+		}
+	}
+
+	private Button CreateButton(BuildingOverlayButtonData buttonData) {
+		var button = new Button {
+			CustomMinimumSize = new Vector2(80, 80),
+			SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
+			Text = buttonData.LabelName,
+			Icon = LoadIcon(buttonData.IconPath),
+			IconAlignment = HorizontalAlignment.Center,
+			VerticalIconAlignment = VerticalAlignment.Top,
+			ExpandIcon = true,
+		};
+
+		button.Pressed += () => OpenPathController(buttonData);
+		return button;
+	}
+
+	private Texture2D LoadIcon(string iconPath) {
+		if (string.IsNullOrWhiteSpace(iconPath))
+			return _fallbackIcon;
+
+		return ResourceLoader.Load<Texture2D>(iconPath) ?? _fallbackIcon;
+	}
+
+	private static void OpenPathController(BuildingOverlayButtonData buttonData) {
+		if (buttonData.PathController == null) {
+			GD.PushWarning($"Building overlay button '{buttonData.LabelName}' has no path controller configured.");
+			return;
+		}
+
+		GlobalOverlay.Get()?.AddOverlay(buttonData.PathController);
+	}
+}

--- a/scenes/components/outpost/BuildingData.cs.uid
+++ b/scenes/components/outpost/BuildingData.cs.uid
@@ -1,0 +1,1 @@
+uid://cd5blmxgvl3oe

--- a/scenes/components/outpost/BuildingTemplate.cs
+++ b/scenes/components/outpost/BuildingTemplate.cs
@@ -2,9 +2,10 @@ using Godot;
 
 public partial class BuildingTemplate : Node2D {
 	private const ulong OpenDebounceMs = 250;
+	private const string BuildingOverlayPath = "res://scenes/overlays/building/BuildingOverlay.tscn";
 
-	[Export] public PackedScene OverlayScene { get; set; }
-	[Export] public Texture2D TextureHouse { get; set; }
+	[Export] public PackedScene BuildingOverlayScene { get; set; } = GD.Load<PackedScene>(BuildingOverlayPath);
+	[Export] public BuildingData BuildingData { get; set; } = new();
 
 	private Sprite2D _houseSprite;
 	private Area2D _area;
@@ -25,8 +26,8 @@ public partial class BuildingTemplate : Node2D {
 	}
 
 	private void ApplyExportedValues() {
-		if (_houseSprite != null && TextureHouse != null)
-			_houseSprite.Texture = TextureHouse;
+		if (_houseSprite != null && BuildingData?.BuildingTexture != null)
+			_houseSprite.Texture = BuildingData.BuildingTexture;
 	}
 
 	private void OnAreaInputEvent(Node viewport, InputEvent @event, long shapeIdx) {
@@ -39,8 +40,8 @@ public partial class BuildingTemplate : Node2D {
 
 		_lastOpenTimeMs = now;
 
-		if (OverlayScene == null) {
-			GD.PushWarning($"{nameof(BuildingTemplate)} on '{Name}' has no overlay scene configured.");
+		if (BuildingOverlayScene == null) {
+			GD.PushWarning($"{nameof(BuildingTemplate)} on '{Name}' could not load BuildingOverlay.");
 			return;
 		}
 
@@ -50,7 +51,11 @@ public partial class BuildingTemplate : Node2D {
 			return;
 		}
 
-		overlay.AddOverlay(OverlayScene);
+		var overlayInstance = BuildingOverlayScene.Instantiate();
+		if (overlayInstance is BuildingOverlay buildingOverlay)
+			buildingOverlay.Update(BuildingData);
+
+		overlay.AddChild(overlayInstance);
 	}
 
 	private static bool IsPressed(InputEvent @event) {

--- a/scenes/components/outpost/buildingTemplate.tscn
+++ b/scenes/components/outpost/buildingTemplate.tscn
@@ -2,6 +2,14 @@
 
 [ext_resource type="Texture2D" uid="uid://dsqb3fvddhg1s" path="res://assets/outpost/buildings/building_placeholder.svg" id="1_8rcmu"]
 [ext_resource type="Script" uid="uid://bt8a8igubvw8b" path="res://scenes/components/outpost/BuildingTemplate.cs" id="2_lm4d7"]
+[ext_resource type="Script" uid="uid://cd5blmxgvl3oe" path="res://scenes/components/outpost/BuildingData.cs" id="3_building_data"]
+
+[sub_resource type="Resource" id="Resource_building_data"]
+script = ExtResource("3_building_data")
+LabelName = "Building"
+Description = "Interact with this building."
+OwnerText = "Welcome. What do you need?"
+BuildingTexture = ExtResource("1_8rcmu")
 
 [sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_13jms"]
 size = Vector2(64, 64)
@@ -11,7 +19,7 @@ radius = 61.03278
 
 [node name="Building" type="Node2D" unique_id=1511369869]
 script = ExtResource("2_lm4d7")
-TextureHouse = ExtResource("1_8rcmu")
+BuildingData = SubResource("Resource_building_data")
 
 [node name="SpriteHouse" type="Sprite2D" parent="." unique_id=333691828]
 texture = ExtResource("1_8rcmu")

--- a/scenes/components/outpost/contract_building_data.tres
+++ b/scenes/components/outpost/contract_building_data.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="BuildingData" format=3 uid="uid://dc5yw0wdd4tyc"]
+
+[ext_resource type="Script" uid="uid://enkabhmf46kb" path="res://scenes/overlays/building/BuildingOverlayButtonData.cs" id="1_2fvkw"]
+[ext_resource type="Script" uid="uid://cd5blmxgvl3oe" path="res://scenes/components/outpost/BuildingData.cs" id="1_contract"]
+
+[resource]
+script = ExtResource("1_contract")
+LabelName = "Contract"
+Description = "Choose the next contract for this run."
+OwnerText = "Contracts are waiting. Pick carefully; the outpost only pays for work that gets finished."

--- a/scenes/components/outpost/inn_building_data.tres
+++ b/scenes/components/outpost/inn_building_data.tres
@@ -1,0 +1,9 @@
+[gd_resource type="Resource" script_class="BuildingData" load_steps=2 format=3]
+
+[ext_resource type="Script" uid="uid://cd5blmxgvl3oe" path="res://scenes/components/outpost/BuildingData.cs" id="1_inn"]
+
+[resource]
+script = ExtResource("1_inn")
+LabelName = "Inn"
+Description = "Rest, recover, and prepare for the next contract."
+OwnerText = "Welcome in. Take a seat, warm up, and breathe before the road calls again."

--- a/scenes/main/outpost/Outpost.tscn
+++ b/scenes/main/outpost/Outpost.tscn
@@ -4,12 +4,14 @@
 [ext_resource type="Script" uid="uid://cojt55fjm1e35" path="res://core/ui/ChangeOverlayScene.cs" id="1_bgakn"]
 [ext_resource type="Script" uid="uid://bn7lsfu8p7umr" path="res://core/ui/OpenOverlay.cs" id="2_6amyp"]
 [ext_resource type="Theme" uid="uid://2us73xfo2hnd" path="res://assets/style/DefaultTheme.tres" id="2_vumbe"]
+[ext_resource type="Resource" path="res://scenes/components/outpost/contract_building_data.tres" id="3_contract_data"]
+[ext_resource type="Script" uid="uid://gifxs8nfold4" path="res://scenes/main/outpost/OutpostBuildings.cs" id="4_3fain"]
 [ext_resource type="PackedScene" uid="uid://b1kf2xl55ull2" path="res://scenes/components/panels/PanelGold.tscn" id="4_b38rb"]
+[ext_resource type="Resource" path="res://scenes/components/outpost/inn_building_data.tres" id="4_inn_data"]
 [ext_resource type="PackedScene" uid="uid://cpis4v08h0ebo" path="res://scenes/components/panels/PanelLocation.tscn" id="5_wqu6w"]
 [ext_resource type="PackedScene" uid="uid://fqd6rdrheta3" path="res://scenes/components/panels/PanelPlayerTop.tscn" id="6_imbua"]
-[ext_resource type="PackedScene" uid="uid://hwrt00phvgys" path="res://scenes/overlays/building/BuildingOverlay.tscn" id="8_nw8ct"]
 [ext_resource type="PackedScene" uid="uid://ctji244a31gb0" path="res://scenes/main/main_menu/StartMenu.tscn" id="9_bgakn"]
-[ext_resource type="PackedScene" path="res://scenes/overlays/main_menu/CodexOverlay.tscn" id="10_codex"]
+[ext_resource type="PackedScene" uid="uid://bewk1qfwxhqaf" path="res://scenes/overlays/main_menu/CodexOverlay.tscn" id="10_codex"]
 [ext_resource type="PackedScene" path="res://scenes/overlays/main_menu/SettingsOverlay.tscn" id="11_settings"]
 [ext_resource type="PackedScene" uid="uid://b8o2ydskyt0q1" path="res://scenes/overlays/inventory/InventoryOverlay.tscn" id="12_inventory"]
 [ext_resource type="PackedScene" path="res://scenes/overlays/character/CharacterOverlay.tscn" id="13_character"]
@@ -141,21 +143,26 @@ metadata/_custom_type_script = "uid://bn7lsfu8p7umr"
 
 [node name="World" type="Node2D" parent="." unique_id=1723193871]
 
-[node name="Building" parent="World" unique_id=1511369869 instance=ExtResource("1_7r7tj")]
-position = Vector2(204, 393)
-OverlayScene = ExtResource("8_nw8ct")
+[node name="OutpostBuildings" type="Node2D" parent="World" unique_id=1143238284]
+script = ExtResource("4_3fain")
+BuildingTemplateScene = ExtResource("1_7r7tj")
 
-[node name="Building2" parent="World" unique_id=780541550 instance=ExtResource("1_7r7tj")]
+[node name="RandomSlot1" type="Node2D" parent="World/OutpostBuildings" unique_id=1511369869]
+position = Vector2(204, 393)
+
+[node name="RandomSlot2" type="Node2D" parent="World/OutpostBuildings" unique_id=780541550]
 position = Vector2(414, 252)
 
-[node name="Building3" parent="World" unique_id=1997029538 instance=ExtResource("1_7r7tj")]
-position = Vector2(575, 478)
-
-[node name="Building4" parent="World" unique_id=1919299272 instance=ExtResource("1_7r7tj")]
+[node name="RandomSlot3" type="Node2D" parent="World/OutpostBuildings" unique_id=1919299272]
 position = Vector2(721, 259)
+
+[node name="Contract" parent="World" unique_id=1997029538 instance=ExtResource("1_7r7tj")]
+position = Vector2(575, 478)
+BuildingData = ExtResource("3_contract_data")
+
+[node name="Inn" parent="World" unique_id=1162120890 instance=ExtResource("1_7r7tj")]
+position = Vector2(891, 402)
+BuildingData = ExtResource("4_inn_data")
 
 [node name="Camera2D" type="Camera2D" parent="World" unique_id=2010866043]
 position = Vector2(576, 324)
-
-[node name="Building5" parent="World" unique_id=1162120890 instance=ExtResource("1_7r7tj")]
-position = Vector2(891, 402)

--- a/scenes/main/outpost/OutpostBuildings.cs
+++ b/scenes/main/outpost/OutpostBuildings.cs
@@ -1,0 +1,68 @@
+using Godot;
+using Godot.Collections;
+
+public partial class OutpostBuildings : Node2D {
+	[Export] public PackedScene BuildingTemplateScene { get; set; }
+
+	public override void _Ready() {
+		var saveNode = SaveNode.Get();
+		var buildings = saveNode.RunData.OutpostBuildings;
+
+		if (buildings == null) {
+			buildings = GenerateMockBuildings();
+			saveNode.RunData.OutpostBuildings = buildings;
+			saveNode.SaveRunData();
+		}
+
+		GenerateBuildings(buildings);
+	}
+
+	private void GenerateBuildings(Array<BuildingData> buildings) {
+		if (BuildingTemplateScene == null) {
+			GD.PushWarning($"{nameof(OutpostBuildings)} on '{Name}' has no building template configured.");
+			return;
+		}
+
+		var slotIndex = 0;
+		foreach (var buildingData in buildings) {
+			if (buildingData == null)
+				continue;
+
+			var slot = GetSlot(slotIndex);
+			if (slot == null)
+				break;
+
+			var building = BuildingTemplateScene.Instantiate<BuildingTemplate>();
+			building.BuildingData = buildingData;
+			slot.AddChild(building);
+			slotIndex++;
+		}
+	}
+
+	private Node2D GetSlot(int index) {
+		if (index < 0 || index >= GetChildCount())
+			return null;
+
+		return GetChild(index) as Node2D;
+	}
+
+	private static Array<BuildingData> GenerateMockBuildings() {
+		var placeholderTexture = new PlaceholderTexture2D { Size = new Vector2I(64, 64) };
+
+		return new Array<BuildingData> {
+			new() {
+				LabelName = "Blacksmith",
+				Description = "Forge, repair, and improve equipment.",
+				OwnerText = "Steel remembers every strike. Bring me coin and materials, and I'll make your gear remember victory.",
+				BuildingTexture = placeholderTexture,
+				OwnerTexture = placeholderTexture,
+				OverlayButtons = new Array<BuildingOverlayButtonData> {
+					new() {
+						IconPath = "",
+						LabelName = "Forge"
+					}
+				}
+			}
+		};
+	}
+}

--- a/scenes/main/outpost/OutpostBuildings.cs.uid
+++ b/scenes/main/outpost/OutpostBuildings.cs.uid
@@ -1,0 +1,1 @@
+uid://gifxs8nfold4

--- a/scenes/overlays/building/BuildingOverlay.cs
+++ b/scenes/overlays/building/BuildingOverlay.cs
@@ -1,0 +1,12 @@
+using Godot;
+
+public partial class BuildingOverlay : Control {
+	public void Update(BuildingData buildingData) {
+		if (buildingData == null) {
+			GD.PushWarning($"{nameof(BuildingOverlay)} received no building data.");
+			return;
+		}
+
+		buildingData.Generate(this);
+	}
+}

--- a/scenes/overlays/building/BuildingOverlay.cs.uid
+++ b/scenes/overlays/building/BuildingOverlay.cs.uid
@@ -1,0 +1,1 @@
+uid://bmqhj3sdl0fnb

--- a/scenes/overlays/building/BuildingOverlay.tscn
+++ b/scenes/overlays/building/BuildingOverlay.tscn
@@ -1,11 +1,9 @@
 [gd_scene format=3 uid="uid://hwrt00phvgys"]
 
 [ext_resource type="Theme" uid="uid://2us73xfo2hnd" path="res://assets/style/DefaultTheme.tres" id="1_01qpf"]
-[ext_resource type="Script" uid="uid://bn7lsfu8p7umr" path="res://core/ui/OpenOverlay.cs" id="2_cjdsb"]
+[ext_resource type="Script" uid="uid://bmqhj3sdl0fnb" path="res://scenes/overlays/building/BuildingOverlay.cs" id="2_qrp73"]
 [ext_resource type="Script" uid="uid://b5nexivgcopri" path="res://core/ui/CloseOverlay.cs" id="3_66bgr"]
 [ext_resource type="PackedScene" uid="uid://cbit1hetoxuyt" path="res://scenes/components/panels/PanelBuilding.tscn" id="4_mlke7"]
-
-[sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_urxyx"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_01qpf"]
 
@@ -17,6 +15,7 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("1_01qpf")
+script = ExtResource("2_qrp73")
 
 [node name="Panel" type="ColorRect" parent="." unique_id=164256524]
 layout_mode = 1
@@ -42,45 +41,6 @@ grow_vertical = 0
 theme_override_constants/separation = 16
 metadata/_edit_lock_ = true
 
-[node name="BtnOne" type="Button" parent="BottomUI" unique_id=1807113178]
-custom_minimum_size = Vector2(80, 80)
-layout_mode = 2
-size_flags_horizontal = 3
-text = "$Btn1"
-icon = SubResource("PlaceholderTexture2D_urxyx")
-icon_alignment = 1
-vertical_icon_alignment = 0
-expand_icon = true
-script = ExtResource("2_cjdsb")
-metadata/_custom_type_script = "uid://bn7lsfu8p7umr"
-metadata/_edit_lock_ = true
-
-[node name="BtnTwo" type="Button" parent="BottomUI" unique_id=959787783]
-custom_minimum_size = Vector2(80, 80)
-layout_mode = 2
-size_flags_horizontal = 3
-text = "$Btn2"
-icon = SubResource("PlaceholderTexture2D_urxyx")
-icon_alignment = 1
-vertical_icon_alignment = 0
-expand_icon = true
-script = ExtResource("2_cjdsb")
-metadata/_custom_type_script = "uid://bn7lsfu8p7umr"
-metadata/_edit_lock_ = true
-
-[node name="BtnTree" type="Button" parent="BottomUI" unique_id=1175373288]
-custom_minimum_size = Vector2(80, 80)
-layout_mode = 2
-size_flags_horizontal = 3
-text = "$Btn3"
-icon = SubResource("PlaceholderTexture2D_urxyx")
-icon_alignment = 1
-vertical_icon_alignment = 0
-expand_icon = true
-script = ExtResource("2_cjdsb")
-metadata/_custom_type_script = "uid://bn7lsfu8p7umr"
-metadata/_edit_lock_ = true
-
 [node name="PanelBuilding" parent="." unique_id=2082076853 instance=ExtResource("4_mlke7")]
 layout_mode = 1
 offset_left = 24.0
@@ -99,7 +59,40 @@ offset_right = -24.0
 offset_bottom = -120.0
 theme_override_styles/panel = SubResource("StyleBoxEmpty_01qpf")
 
+[node name="CenterContent" type="HBoxContainer" parent="PanelOverlay" unique_id=645034186]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 24
+alignment = 1
+
+[node name="OwnerPortrait" type="TextureRect" parent="PanelOverlay/CenterContent" unique_id=665627996]
+custom_minimum_size = Vector2(220, 260)
+layout_mode = 2
+size_flags_horizontal = 0
+size_flags_vertical = 4
+expand_mode = 1
+stretch_mode = 5
+
+[node name="DialoguePanel" type="PanelContainer" parent="PanelOverlay/CenterContent" unique_id=1932082057]
+custom_minimum_size = Vector2(520, 220)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 4
+
+[node name="MarginContainer" type="MarginContainer" parent="PanelOverlay/CenterContent/DialoguePanel" unique_id=215597545]
+layout_mode = 2
+
+[node name="OwnerText" type="RichTextLabel" parent="PanelOverlay/CenterContent/DialoguePanel/MarginContainer" unique_id=1638818097]
+layout_mode = 2
+bbcode_enabled = true
+text = "Welcome."
+fit_content = true
+scroll_active = false
+vertical_alignment = 2
+
 [node name="CloseOverlay" type="Button" parent="." unique_id=1959946455 node_paths=PackedStringArray("CloseTarget")]
+modulate = Color(1, 0.15, 0.15, 1)
 custom_minimum_size = Vector2(56, 56)
 layout_mode = 1
 anchors_preset = 1
@@ -110,10 +103,9 @@ offset_top = 24.0
 offset_right = -24.0
 offset_bottom = 80.0
 grow_horizontal = 0
-modulate = Color(1, 0.15, 0.15, 1)
 theme_override_colors/font_color = Color(1, 1, 1, 1)
-theme_override_colors/font_hover_color = Color(1, 1, 1, 1)
 theme_override_colors/font_pressed_color = Color(1, 1, 1, 1)
+theme_override_colors/font_hover_color = Color(1, 1, 1, 1)
 text = "X"
 script = ExtResource("3_66bgr")
 CloseTarget = NodePath("..")

--- a/scenes/overlays/building/BuildingOverlayButtonData.cs
+++ b/scenes/overlays/building/BuildingOverlayButtonData.cs
@@ -1,0 +1,10 @@
+using Godot;
+
+[GlobalClass]
+public partial class BuildingOverlayButtonData : Resource {
+	[Export(PropertyHint.File, "*.png,*.svg,*.jpg,*.jpeg,*.webp,*.tres,*.res")]
+	public string IconPath { get; set; }
+
+	[Export] public string LabelName { get; set; }
+	[Export] public PackedScene PathController { get; set; }
+}

--- a/scenes/overlays/building/BuildingOverlayButtonData.cs.uid
+++ b/scenes/overlays/building/BuildingOverlayButtonData.cs.uid
@@ -1,0 +1,1 @@
+uid://enkabhmf46kb


### PR DESCRIPTION
## Summary
- Add `BuildingData` resources and save generated outpost buildings on `RunData`.
- Add `OutpostBuildings` generation for random slots with mock Blacksmith data.
- Rework building overlays to regenerate from building data and document the outpost flow.

## Validation
- dotnet build SinglePlayerRogueliteV2.csproj

## Notes
- `scenes/main/main_menu/StartMenu.tscn` has an unrelated local UID change and is intentionally not included.