### PR TITLE
Add shared storefront and reset run state

### DIFF
--- a/autoload/save/SaveNode.cs
+++ b/autoload/save/SaveNode.cs
@@ -18,7 +18,7 @@ public partial class SaveNode : Node {
 	public PlayerData[] StartCharacters { get; private set; } = Array.Empty<PlayerData>();
 	public bool HadPlayerDataOnLoad { get; private set; }
 	public PlayerData PlayerData => RunData.PlayerData;
-	public InventoryData InventoryData => RunData.InventoryData;
+	public InventoryData InventoryData => PlayerData.InventoryData;
 	public EquipedItemsData EquipedItemsData => PlayerData.EquipedItems;
 	public static SaveNode Get() => Engine.GetMainLoop() is SceneTree tree ? tree.Root.GetNode<SaveNode>("SaveNode") : throw new InvalidOperationException("SaveNode: Unable to find SaveNode in the scene tree. Ensure that SaveNode is added as a child of the root node and is named 'SaveNode'.");
 	public override void _Ready() {
@@ -35,6 +35,7 @@ public partial class SaveNode : Node {
 			SaveAllData();
 
 		RunData.PlayerData ??= new PlayerData();
+		RunData.PlayerData.InventoryData ??= new InventoryData();
 		RefreshStartCharacters();
 		GD.Print("SaveNode is ready. MetaData, RunData, and SettingsData have been initialized.");
 	}
@@ -158,9 +159,11 @@ public partial class SaveNode : Node {
 	}
 
 	public void WipeRun() {
+		GD.Print("WipeRun: resetting run data.");
 		RunData = new RunData();
 		MetaData ??= new MetaData();
 		MetaData.RunCount++;
+		GD.Print($"WipeRun: run count increased to {MetaData.RunCount}.");
 		SaveMetaData();
 	}
 

--- a/autoload/save/SaveNode.cs
+++ b/autoload/save/SaveNode.cs
@@ -157,6 +157,13 @@ public partial class SaveNode : Node {
 		DeleteData(FileType.Settings);
 	}
 
+	public void WipeRun() {
+		RunData = new RunData();
+		MetaData ??= new MetaData();
+		MetaData.RunCount++;
+		SaveMetaData();
+	}
+
 	public void SaveAllData() {
 		SaveMetaData();
 		SaveRunData();

--- a/autoload/save/data/PlayerData.cs
+++ b/autoload/save/data/PlayerData.cs
@@ -3,11 +3,12 @@ using Godot;
 [GlobalClass]
 public partial class PlayerData : Resource {
 	[Export] public string PlayerName { get; set; } = "Player";
+	[Export] public InventoryData InventoryData { get; set; } = new();
 	[Export] public EquipedItemsData EquipedItems { get; set; } = new();
 	[Export] public PlayerSkillData Skills { get; set; } = new();
 	[Export] public ItemBase StartingItem { get; set; }
 
 	public override string ToString() {
-		return $"PlayerData:\n    PlayerName={PlayerName}\n    EquipedItems={EquipedItems}\n    Skills={Skills}\n    StartingItem={StartingItem}";
+		return $"PlayerData:\n    PlayerName={PlayerName}\n    InventoryData={InventoryData}\n    EquipedItems={EquipedItems}\n    Skills={Skills}\n    StartingItem={StartingItem}";
 	}
 }

--- a/autoload/save/data/RunData.cs
+++ b/autoload/save/data/RunData.cs
@@ -9,7 +9,6 @@ namespace SaveData {
 		[Export] public Locations CurrentLocation { get; set; } = Locations.Village;
 		[Export] public PlayerData PlayerData { get; set; } = new PlayerData();
 		[Export] public Contract CurrentContract { get; set; } = null;
-		[Export] public InventoryData InventoryData { get; set; } = new InventoryData();
 		[Export] public Array<BuildingData> OutpostBuildings { get; set; }
 		[Export] public int ContractsCompleted { get; set; } = 0;
 		[Export] public int Gold { get; set; } = 100;
@@ -19,7 +18,6 @@ namespace SaveData {
 				+ $"  CurrentLocation={CurrentLocation}\n"
 				+ $"  PlayerData={FormatResource(PlayerData)}\n"
 				+ $"  CurrentContract={FormatResource(CurrentContract)}\n"
-				+ $"  InventoryData={FormatResource(InventoryData)}\n"
 				+ $"  OutpostBuildings={OutpostBuildings?.Count ?? 0}\n"
 				+ $"  ContractsCompleted={ContractsCompleted}\n"
 				+ $"  Gold={Gold}";

--- a/core/buildings/data/blacksmith.tres
+++ b/core/buildings/data/blacksmith.tres
@@ -7,6 +7,13 @@
 [ext_resource type="Resource" path="res://core/items/data/health_potion.tres" id="5_health_potion"]
 [ext_resource type="Resource" path="res://core/items/data/leather_armor.tres" id="6_leather_armor"]
 
+[sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_building"]
+size = Vector2(64, 64)
+
+[sub_resource type="Resource" id="Resource_forge_button"]
+script = ExtResource("2_button")
+LabelName = "Forge"
+
 [sub_resource type="Resource" id="Resource_shop_button"]
 script = ExtResource("2_button")
 LabelName = "Shop"
@@ -14,8 +21,10 @@ PathController = ExtResource("3_storefront")
 
 [resource]
 script = ExtResource("1_building")
-LabelName = "Storefront"
-Description = "Buy useful supplies before leaving the outpost."
-OwnerText = "Coin on the counter, goods in the bag. Take a look before the roads take their share."
-OverlayButtons = Array[Resource]([SubResource("Resource_shop_button")])
+LabelName = "Blacksmith"
+Description = "Forge, repair, and improve equipment."
+OwnerText = "Steel remembers every strike. Bring me coin and materials, and I'll make your gear remember victory."
+OwnerTexture = SubResource("PlaceholderTexture2D_building")
+BuildingTexture = SubResource("PlaceholderTexture2D_building")
+OverlayButtons = Array[Resource]([SubResource("Resource_forge_button"), SubResource("Resource_shop_button")])
 StorefrontItems = Array[Resource]([ExtResource("4_iron_sword"), ExtResource("5_health_potion"), ExtResource("6_leather_armor")])

--- a/core/buildings/data/general_goods.tres
+++ b/core/buildings/data/general_goods.tres
@@ -1,0 +1,26 @@
+[gd_resource type="Resource" script_class="BuildingData" load_steps=8 format=3]
+
+[ext_resource type="Script" uid="uid://cd5blmxgvl3oe" path="res://scenes/components/outpost/BuildingData.cs" id="1_building"]
+[ext_resource type="Script" uid="uid://enkabhmf46kb" path="res://scenes/overlays/building/BuildingOverlayButtonData.cs" id="2_button"]
+[ext_resource type="PackedScene" path="res://scenes/overlays/storefront/StorefrontOverlay.tscn" id="3_storefront"]
+[ext_resource type="Resource" path="res://core/items/data/health_potion.tres" id="4_health_potion"]
+[ext_resource type="Resource" path="res://core/items/data/arrow_bundle.tres" id="5_arrow_bundle"]
+[ext_resource type="Resource" path="res://core/items/data/hunter_bow.tres" id="6_hunter_bow"]
+
+[sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_building"]
+size = Vector2(64, 64)
+
+[sub_resource type="Resource" id="Resource_shop_button"]
+script = ExtResource("2_button")
+LabelName = "Shop"
+PathController = ExtResource("3_storefront")
+
+[resource]
+script = ExtResource("1_building")
+LabelName = "General Goods"
+Description = "Basic travel supplies for contracts and recovery."
+OwnerText = "Nothing fancy, nothing cursed, and mostly nothing that bites. Tell me what you're missing."
+OwnerTexture = SubResource("PlaceholderTexture2D_building")
+BuildingTexture = SubResource("PlaceholderTexture2D_building")
+OverlayButtons = Array[Resource]([SubResource("Resource_shop_button")])
+StorefrontItems = Array[Resource]([ExtResource("4_health_potion"), ExtResource("5_arrow_bundle"), ExtResource("6_hunter_bow")])

--- a/core/buildings/data/jeweler.tres
+++ b/core/buildings/data/jeweler.tres
@@ -1,0 +1,24 @@
+[gd_resource type="Resource" script_class="BuildingData" load_steps=6 format=3]
+
+[ext_resource type="Script" uid="uid://cd5blmxgvl3oe" path="res://scenes/components/outpost/BuildingData.cs" id="1_building"]
+[ext_resource type="Script" uid="uid://enkabhmf46kb" path="res://scenes/overlays/building/BuildingOverlayButtonData.cs" id="2_button"]
+[ext_resource type="PackedScene" path="res://scenes/overlays/storefront/StorefrontOverlay.tscn" id="3_storefront"]
+[ext_resource type="Resource" path="res://core/items/data/wolf_amulet.tres" id="4_wolf_amulet"]
+
+[sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_building"]
+size = Vector2(64, 64)
+
+[sub_resource type="Resource" id="Resource_shop_button"]
+script = ExtResource("2_button")
+LabelName = "Shop"
+PathController = ExtResource("3_storefront")
+
+[resource]
+script = ExtResource("1_building")
+LabelName = "Jeweler"
+Description = "Trade in amulets, charms, and polished valuables."
+OwnerText = "Every stone has a temperament. Spend carefully, and it might choose to favor you."
+OwnerTexture = SubResource("PlaceholderTexture2D_building")
+BuildingTexture = SubResource("PlaceholderTexture2D_building")
+OverlayButtons = Array[Resource]([SubResource("Resource_shop_button")])
+StorefrontItems = Array[Resource]([ExtResource("4_wolf_amulet")])

--- a/scenes/components/character/NewCharacterComponent.cs
+++ b/scenes/components/character/NewCharacterComponent.cs
@@ -44,8 +44,10 @@ public partial class NewCharacterComponent : Control {
 
 	private void OnSelectPressed() {
 		var saveNode = SaveNode.Get();
-		saveNode.RunData.PlayerData = PlayerData;
+		saveNode.WipeRun();
+		saveNode.RunData.PlayerData = PlayerData.Duplicate(true) as PlayerData ?? new PlayerData();
 		saveNode.RunData.InventoryData = new InventoryData();
+
 		if (PlayerData.StartingItem != null)
 			saveNode.RunData.InventoryData.AddItem(PlayerData.StartingItem.Duplicate(true) as ItemBase);
 

--- a/scenes/components/character/NewCharacterComponent.cs
+++ b/scenes/components/character/NewCharacterComponent.cs
@@ -46,12 +46,11 @@ public partial class NewCharacterComponent : Control {
 		var saveNode = SaveNode.Get();
 		saveNode.WipeRun();
 		saveNode.RunData.PlayerData = PlayerData.Duplicate(true) as PlayerData ?? new PlayerData();
-		saveNode.RunData.InventoryData = new InventoryData();
+		saveNode.RunData.PlayerData.InventoryData = new InventoryData();
 
 		if (PlayerData.StartingItem != null)
-			saveNode.RunData.InventoryData.AddItem(PlayerData.StartingItem.Duplicate(true) as ItemBase);
+			saveNode.RunData.PlayerData.InventoryData.AddItem(PlayerData.StartingItem.Duplicate(true) as ItemBase);
 
-		saveNode.SaveRunData();
 		saveNode.RefreshStartCharacters();
 
 		CallDeferred(MethodName.GoToOutpost);

--- a/scenes/components/outpost/BuildingData.cs
+++ b/scenes/components/outpost/BuildingData.cs
@@ -12,6 +12,7 @@ public partial class BuildingData : Resource {
 	[Export] public double OwnerTextRevealSeconds { get; set; } = 1.5;
 	[Export] public Texture2D BuildingTexture { get; set; }
 	[Export] public Array<BuildingOverlayButtonData> OverlayButtons { get; set; } = new();
+	[Export] public Array<ItemBase> StorefrontItems { get; set; } = new();
 
 	public void Generate(BuildingOverlay overlay) {
 		if (overlay == null)
@@ -75,12 +76,16 @@ public partial class BuildingData : Resource {
 		return ResourceLoader.Load<Texture2D>(iconPath) ?? _fallbackIcon;
 	}
 
-	private static void OpenPathController(BuildingOverlayButtonData buttonData) {
+	private void OpenPathController(BuildingOverlayButtonData buttonData) {
 		if (buttonData.PathController == null) {
 			GD.PushWarning($"Building overlay button '{buttonData.LabelName}' has no path controller configured.");
 			return;
 		}
 
-		GlobalOverlay.Get()?.AddOverlay(buttonData.PathController);
+		var overlay = buttonData.PathController.Instantiate();
+		if (overlay is StorefrontOverlay storefrontOverlay)
+			storefrontOverlay.Update(this);
+
+		GlobalOverlay.Get()?.AddChild(overlay);
 	}
 }

--- a/scenes/components/outpost/storefront_building_data.tres
+++ b/scenes/components/outpost/storefront_building_data.tres
@@ -1,0 +1,21 @@
+[gd_resource type="Resource" script_class="BuildingData" load_steps=8 format=3]
+
+[ext_resource type="Script" uid="uid://cd5blmxgvl3oe" path="res://scenes/components/outpost/BuildingData.cs" id="1_building"]
+[ext_resource type="Script" uid="uid://enkabhmf46kb" path="res://scenes/overlays/building/BuildingOverlayButtonData.cs" id="2_button"]
+[ext_resource type="PackedScene" path="res://scenes/overlays/storefront/StorefrontOverlay.tscn" id="3_storefront"]
+[ext_resource type="Resource" path="res://core/items/data/iron_sword.tres" id="4_iron_sword"]
+[ext_resource type="Resource" path="res://core/items/data/health_potion.tres" id="5_health_potion"]
+[ext_resource type="Resource" path="res://core/items/data/leather_armor.tres" id="6_leather_armor"]
+
+[sub_resource type="Resource" id="Resource_shop_button"]
+script = ExtResource("2_button")
+LabelName = "Shop"
+PathController = ExtResource("3_storefront")
+
+[resource]
+script = ExtResource("1_building")
+LabelName = "Storefront"
+Description = "Buy useful supplies before leaving the outpost."
+OwnerText = "Coin on the counter, goods in the bag. Take a look before the roads take their share."
+OverlayButtons = Array[Resource]([SubResource("Resource_shop_button")])
+StorefrontItems = Array[Resource]([ExtResource("4_iron_sword"), ExtResource("5_health_potion"), ExtResource("6_leather_armor")])

--- a/scenes/main/outpost/OutpostBuildings.cs
+++ b/scenes/main/outpost/OutpostBuildings.cs
@@ -48,6 +48,7 @@ public partial class OutpostBuildings : Node2D {
 
 	private static Array<BuildingData> GenerateMockBuildings() {
 		var placeholderTexture = new PlaceholderTexture2D { Size = new Vector2I(64, 64) };
+		var storefrontScene = GD.Load<PackedScene>("res://scenes/overlays/storefront/StorefrontOverlay.tscn");
 
 		return new Array<BuildingData> {
 			new() {
@@ -60,7 +61,17 @@ public partial class OutpostBuildings : Node2D {
 					new() {
 						IconPath = "",
 						LabelName = "Forge"
+					},
+					new() {
+						IconPath = "",
+						LabelName = "Shop",
+						PathController = storefrontScene
 					}
+				},
+				StorefrontItems = new Array<ItemBase> {
+					new ItemBase("Iron Sword", null, placeholderTexture, 1, 100),
+					new ItemBase("Repair Kit", null, placeholderTexture, 5, 40),
+					new ItemBase("Steel Buckler", null, placeholderTexture, 1, 140)
 				}
 			}
 		};

--- a/scenes/main/outpost/OutpostBuildings.cs
+++ b/scenes/main/outpost/OutpostBuildings.cs
@@ -2,8 +2,7 @@ using Godot;
 using Godot.Collections;
 
 public partial class OutpostBuildings : Node2D {
-	private const int MinGeneratedBuildings = 1;
-	private const int MaxGeneratedBuildings = 3;
+	private const int MinGeneratedBuildings = 0;
 	private static readonly string[] PossibleBuildingPaths = {
 		"res://core/buildings/data/blacksmith.tres",
 		"res://core/buildings/data/jeweler.tres",
@@ -16,8 +15,8 @@ public partial class OutpostBuildings : Node2D {
 		var saveNode = SaveNode.Get();
 		var buildings = saveNode.RunData.OutpostBuildings;
 
-		if (buildings == null) {
-			buildings = GenerateMockBuildings();
+		if (buildings == null || buildings.Count != GetChildCount()) {
+			buildings = GenerateOutpostBuildings();
 			saveNode.RunData.OutpostBuildings = buildings;
 			saveNode.SaveRunData();
 		}
@@ -31,8 +30,8 @@ public partial class OutpostBuildings : Node2D {
 			return;
 		}
 
-		var slotIndex = 0;
-		foreach (var buildingData in buildings) {
+		for (var slotIndex = 0; slotIndex < buildings.Count; slotIndex++) {
+			var buildingData = buildings[slotIndex];
 			if (buildingData == null)
 				continue;
 
@@ -43,7 +42,6 @@ public partial class OutpostBuildings : Node2D {
 			var building = BuildingTemplateScene.Instantiate<BuildingTemplate>();
 			building.BuildingData = buildingData;
 			slot.AddChild(building);
-			slotIndex++;
 		}
 	}
 
@@ -54,23 +52,39 @@ public partial class OutpostBuildings : Node2D {
 		return GetChild(index) as Node2D;
 	}
 
-	private static Array<BuildingData> GenerateMockBuildings() {
+	private Array<BuildingData> GenerateOutpostBuildings() {
 		var buildings = new Array<BuildingData>();
 		var remainingPaths = new Array<string>(PossibleBuildingPaths);
+		var remainingSlots = new Array<int>();
 		var random = new RandomNumberGenerator();
 		random.Randomize();
-		var buildingCount = random.RandiRange(MinGeneratedBuildings, Mathf.Min(MaxGeneratedBuildings, remainingPaths.Count));
+
+		for (var slotIndex = 0; slotIndex < GetChildCount(); slotIndex++) {
+			buildings.Add(null);
+			remainingSlots.Add(slotIndex);
+		}
+
+		var maxBuildingCount = Mathf.Min(remainingPaths.Count, remainingSlots.Count);
+		var buildingCount = random.RandiRange(MinGeneratedBuildings, maxBuildingCount);
 
 		for (var i = 0; i < buildingCount; i++) {
 			var pathIndex = random.RandiRange(0, remainingPaths.Count - 1);
 			var buildingPath = remainingPaths[pathIndex];
 			remainingPaths.RemoveAt(pathIndex);
+			var slotIndex = TakeRandomSlot(remainingSlots, random);
 
 			var buildingData = ResourceLoader.Load<BuildingData>(buildingPath);
 			if (buildingData != null)
-				buildings.Add(buildingData);
+				buildings[slotIndex] = buildingData;
 		}
 
 		return buildings;
+	}
+
+	private static int TakeRandomSlot(Array<int> slots, RandomNumberGenerator random) {
+		var slotListIndex = random.RandiRange(0, slots.Count - 1);
+		var slotIndex = slots[slotListIndex];
+		slots.RemoveAt(slotListIndex);
+		return slotIndex;
 	}
 }

--- a/scenes/main/outpost/OutpostBuildings.cs
+++ b/scenes/main/outpost/OutpostBuildings.cs
@@ -2,6 +2,14 @@ using Godot;
 using Godot.Collections;
 
 public partial class OutpostBuildings : Node2D {
+	private const int MinGeneratedBuildings = 1;
+	private const int MaxGeneratedBuildings = 3;
+	private static readonly string[] PossibleBuildingPaths = {
+		"res://core/buildings/data/blacksmith.tres",
+		"res://core/buildings/data/jeweler.tres",
+		"res://core/buildings/data/general_goods.tres"
+	};
+
 	[Export] public PackedScene BuildingTemplateScene { get; set; }
 
 	public override void _Ready() {
@@ -47,33 +55,22 @@ public partial class OutpostBuildings : Node2D {
 	}
 
 	private static Array<BuildingData> GenerateMockBuildings() {
-		var placeholderTexture = new PlaceholderTexture2D { Size = new Vector2I(64, 64) };
-		var storefrontScene = GD.Load<PackedScene>("res://scenes/overlays/storefront/StorefrontOverlay.tscn");
+		var buildings = new Array<BuildingData>();
+		var remainingPaths = new Array<string>(PossibleBuildingPaths);
+		var random = new RandomNumberGenerator();
+		random.Randomize();
+		var buildingCount = random.RandiRange(MinGeneratedBuildings, Mathf.Min(MaxGeneratedBuildings, remainingPaths.Count));
 
-		return new Array<BuildingData> {
-			new() {
-				LabelName = "Blacksmith",
-				Description = "Forge, repair, and improve equipment.",
-				OwnerText = "Steel remembers every strike. Bring me coin and materials, and I'll make your gear remember victory.",
-				BuildingTexture = placeholderTexture,
-				OwnerTexture = placeholderTexture,
-				OverlayButtons = new Array<BuildingOverlayButtonData> {
-					new() {
-						IconPath = "",
-						LabelName = "Forge"
-					},
-					new() {
-						IconPath = "",
-						LabelName = "Shop",
-						PathController = storefrontScene
-					}
-				},
-				StorefrontItems = new Array<ItemBase> {
-					new ItemBase("Iron Sword", null, placeholderTexture, 1, 100),
-					new ItemBase("Repair Kit", null, placeholderTexture, 5, 40),
-					new ItemBase("Steel Buckler", null, placeholderTexture, 1, 140)
-				}
-			}
-		};
+		for (var i = 0; i < buildingCount; i++) {
+			var pathIndex = random.RandiRange(0, remainingPaths.Count - 1);
+			var buildingPath = remainingPaths[pathIndex];
+			remainingPaths.RemoveAt(pathIndex);
+
+			var buildingData = ResourceLoader.Load<BuildingData>(buildingPath);
+			if (buildingData != null)
+				buildings.Add(buildingData);
+		}
+
+		return buildings;
 	}
 }

--- a/scenes/overlays/storefront/StorefrontOverlay.cs
+++ b/scenes/overlays/storefront/StorefrontOverlay.cs
@@ -1,0 +1,135 @@
+using Godot;
+
+public partial class StorefrontOverlay : Control {
+	private GridContainer _itemGrid;
+	private Label _emptyLabel;
+	private TextureRect _previewIcon;
+	private Label _previewDetails;
+	private Label _priceLabel;
+	private Button _purchaseButton;
+	private readonly PlaceholderTexture2D _placeholderIcon = new() { Size = new Vector2I(64, 64) };
+	private BuildingData _buildingData;
+	private ItemBase _selectedItem;
+
+	public override void _Ready() {
+		_itemGrid = GetNode<GridContainer>("Content/StorePanel/MarginContainer/StoreLayout/ItemGrid");
+		_emptyLabel = GetNode<Label>("Content/StorePanel/MarginContainer/StoreLayout/EmptyLabel");
+		_previewIcon = GetNode<TextureRect>("Content/PreviewPanel/MarginContainer/PreviewLayout/PreviewIcon");
+		_previewDetails = GetNode<Label>("Content/PreviewPanel/MarginContainer/PreviewLayout/PreviewDetails");
+		_priceLabel = GetNode<Label>("Content/PreviewPanel/MarginContainer/PreviewLayout/PriceLabel");
+		_purchaseButton = GetNode<Button>("Content/PreviewPanel/MarginContainer/PreviewLayout/PurchaseButton");
+
+		_purchaseButton.Pressed += PurchaseSelectedItem;
+		SignalHandler.SubscribeGoldAmountChanged(OnGoldAmountChanged);
+		Render();
+	}
+
+	public override void _ExitTree() {
+		SignalHandler.UnsubscribeGoldAmountChanged(OnGoldAmountChanged);
+	}
+
+	public void Update(BuildingData buildingData) {
+		_buildingData = buildingData;
+		_selectedItem = null;
+
+		if (IsNodeReady())
+			Render();
+	}
+
+	private void Render() {
+		RenderItems();
+		RenderPreview();
+	}
+
+	private void RenderItems() {
+		foreach (var child in _itemGrid.GetChildren())
+			child.QueueFree();
+
+		var items = _buildingData?.StorefrontItems;
+		var hasItems = items != null && items.Count > 0;
+		_itemGrid.Visible = hasItems;
+		_emptyLabel.Visible = !hasItems;
+
+		if (!hasItems)
+			return;
+
+		foreach (var item in items) {
+			if (item == null)
+				continue;
+
+			_itemGrid.AddChild(CreateItemButton(item));
+		}
+	}
+
+	private Button CreateItemButton(ItemBase item) {
+		var button = new Button {
+			CustomMinimumSize = new Vector2(132, 92),
+			SizeFlagsHorizontal = SizeFlags.ExpandFill,
+			SizeFlagsVertical = SizeFlags.ExpandFill,
+			Text = item.ItemName,
+			Icon = item.Icon ?? _placeholderIcon,
+			IconAlignment = HorizontalAlignment.Center,
+			VerticalIconAlignment = VerticalAlignment.Top,
+			ExpandIcon = true,
+			ClipText = true,
+			AutowrapMode = TextServer.AutowrapMode.WordSmart
+		};
+
+		button.Pressed += () => SelectItem(item);
+		return button;
+	}
+
+	private void SelectItem(ItemBase item) {
+		_selectedItem = item;
+		RenderPreview();
+	}
+
+	private void RenderPreview() {
+		if (_selectedItem == null) {
+			_previewIcon.Texture = _placeholderIcon;
+			_previewDetails.Text = "Select an item to preview it.";
+			_priceLabel.Text = "Price: -";
+			_purchaseButton.Disabled = true;
+			return;
+		}
+
+		_previewIcon.Texture = _selectedItem.Icon ?? _placeholderIcon;
+		_previewDetails.Text = FormatItemDetails(_selectedItem);
+		_priceLabel.Text = $"Price: {_selectedItem.Cost}";
+		_purchaseButton.Disabled = !CanPurchase(_selectedItem);
+	}
+
+	private bool CanPurchase(ItemBase item) {
+		var saveNode = SaveNode.Get();
+		return item != null && saveNode?.RunData != null && saveNode.RunData.Gold >= item.Cost;
+	}
+
+	private void PurchaseSelectedItem() {
+		if (!CanPurchase(_selectedItem)) {
+			RenderPreview();
+			return;
+		}
+
+		var saveNode = SaveNode.Get();
+		saveNode.RunData.Gold -= _selectedItem.Cost;
+		saveNode.InventoryData.AddItem(_selectedItem);
+		_buildingData.StorefrontItems.Remove(_selectedItem);
+		saveNode.SaveRunData();
+
+		SignalHandler.EmitSignalPurchaseItemStatic(_selectedItem);
+		SignalHandler.EmitSignalGoldAmountChangedStatic(saveNode.RunData.Gold);
+
+		var purchasedItemName = _selectedItem.ItemName;
+		_selectedItem = null;
+		Render();
+		_previewDetails.Text = $"Purchased {purchasedItemName}.";
+	}
+
+	private void OnGoldAmountChanged(int goldAmount) {
+		RenderPreview();
+	}
+
+	private static string FormatItemDetails(ItemBase item) {
+		return $"{item.ItemName}\nStack: {item.MaxStackSize}";
+	}
+}

--- a/scenes/overlays/storefront/StorefrontOverlay.cs.uid
+++ b/scenes/overlays/storefront/StorefrontOverlay.cs.uid
@@ -1,0 +1,1 @@
+uid://c1ljtdokxvm2b

--- a/scenes/overlays/storefront/StorefrontOverlay.tscn
+++ b/scenes/overlays/storefront/StorefrontOverlay.tscn
@@ -1,0 +1,155 @@
+[gd_scene format=3]
+
+[ext_resource type="Theme" uid="uid://2us73xfo2hnd" path="res://assets/style/DefaultTheme.tres" id="1_theme"]
+[ext_resource type="Script" uid="uid://c1ljtdokxvm2b" path="res://scenes/overlays/storefront/StorefrontOverlay.cs" id="2_script"]
+[ext_resource type="Script" uid="uid://b5nexivgcopri" path="res://core/ui/CloseOverlay.cs" id="3_close"]
+
+[sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_preview"]
+size = Vector2(64, 64)
+
+[node name="StorefrontOverlay" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_theme")
+script = ExtResource("2_script")
+
+[node name="Panel" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.393086, 0.393086, 0.393086, 1)
+
+[node name="Content" type="HBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 24.0
+offset_top = 88.0
+offset_right = -24.0
+offset_bottom = -24.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 16
+
+[node name="StorePanel" type="PanelContainer" parent="Content"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+size_flags_stretch_ratio = 2.0
+
+[node name="MarginContainer" type="MarginContainer" parent="Content/StorePanel"]
+layout_mode = 2
+theme_override_constants/margin_left = 12
+theme_override_constants/margin_top = 12
+theme_override_constants/margin_right = 12
+theme_override_constants/margin_bottom = 12
+
+[node name="StoreLayout" type="VBoxContainer" parent="Content/StorePanel/MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 12
+
+[node name="Title" type="Label" parent="Content/StorePanel/MarginContainer/StoreLayout"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 36
+text = "Storefront"
+horizontal_alignment = 1
+
+[node name="ItemGrid" type="GridContainer" parent="Content/StorePanel/MarginContainer/StoreLayout"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/h_separation = 12
+theme_override_constants/v_separation = 12
+columns = 4
+
+[node name="EmptyLabel" type="Label" parent="Content/StorePanel/MarginContainer/StoreLayout"]
+visible = false
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+text = "Nothing is for sale right now."
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="PreviewPanel" type="PanelContainer" parent="Content"]
+custom_minimum_size = Vector2(260, 0)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="MarginContainer" type="MarginContainer" parent="Content/PreviewPanel"]
+layout_mode = 2
+theme_override_constants/margin_left = 12
+theme_override_constants/margin_top = 12
+theme_override_constants/margin_right = 12
+theme_override_constants/margin_bottom = 12
+
+[node name="PreviewLayout" type="VBoxContainer" parent="Content/PreviewPanel/MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 12
+alignment = 1
+
+[node name="PreviewTitle" type="Label" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 28
+text = "Preview"
+horizontal_alignment = 1
+
+[node name="PreviewIcon" type="TextureRect" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
+custom_minimum_size = Vector2(96, 96)
+layout_mode = 2
+size_flags_horizontal = 4
+texture = SubResource("PlaceholderTexture2D_preview")
+expand_mode = 1
+stretch_mode = 5
+
+[node name="PreviewDetails" type="Label" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
+custom_minimum_size = Vector2(0, 96)
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Select an item to preview it."
+horizontal_alignment = 1
+vertical_alignment = 1
+autowrap_mode = 3
+
+[node name="PriceLabel" type="Label" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 24
+text = "Price: -"
+horizontal_alignment = 1
+
+[node name="PurchaseButton" type="Button" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
+custom_minimum_size = Vector2(160, 56)
+layout_mode = 2
+size_flags_horizontal = 4
+disabled = true
+text = "Purchase"
+
+[node name="CloseOverlay" type="Button" parent="." node_paths=PackedStringArray("CloseTarget")]
+modulate = Color(1, 0.15, 0.15, 1)
+custom_minimum_size = Vector2(56, 56)
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -80.0
+offset_top = 24.0
+offset_right = -24.0
+offset_bottom = 80.0
+grow_horizontal = 0
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_colors/font_pressed_color = Color(1, 1, 1, 1)
+theme_override_colors/font_hover_color = Color(1, 1, 1, 1)
+text = "X"
+script = ExtResource("3_close")
+CloseTarget = NodePath("..")
+CloseAllOverlayChildren = true
+metadata/_custom_type_script = "uid://b5nexivgcopri"


### PR DESCRIPTION
## Summary
- add a shared storefront overlay and move outpost building templates into reusable resource data
- randomize outpost buildings into random slots per run and reset run state when selecting a new character
- move inventory ownership into player data and centralize new-run reset logic in `SaveNode.WipeRun()`