### PR TITLE
Add run flow small fixes

### DIFF
--- a/Ai-Summary/save-run-outpost-context.md
+++ b/Ai-Summary/save-run-outpost-context.md
@@ -1,0 +1,85 @@
+# Save / Run / Outpost Context
+
+Updated on `smallfix` after the following commits:
+- `fe5c1ab` Limit new run button visibility
+- `ecb3266` Add contract completion run transition
+
+## SaveNode flow
+
+- `SaveNode.RunData` is the active run state.
+- `SaveNode.WipeRun()` is the central reset path for starting a new run.
+- `WipeRun()`:
+  - replaces `RunData` with a fresh `RunData`
+  - increments `MetaData.RunCount`
+  - saves metadata immediately
+
+## Player / inventory ownership
+
+- Inventory is intended to be player-owned, not run-owned.
+- `InventoryData` belongs on `PlayerData`.
+- `SaveNode.InventoryData` should resolve through `PlayerData.InventoryData`.
+- New character selection should:
+  - call `WipeRun()`
+  - assign the selected duplicated `PlayerData`
+  - initialize that player's inventory
+  - add duplicated starting item into that player inventory
+
+## Outpost generation
+
+- Outpost buildings are stored in `RunData.OutpostBuildings`.
+- The array is slot-based, not compacted:
+  - `null` means empty slot
+  - non-null `BuildingData` means that slot spawns a building
+- New outposts should generate a random count from `0..available`
+- Building types are selected from the configured resource pool without replacement.
+- Chosen buildings are placed into random slots without replacement.
+- If saved outpost data is missing or has the wrong slot count, it should be regenerated.
+
+Example layouts:
+- `E, E, E`
+- `E, B, C`
+- `A, E, B`
+
+## Building resources
+
+Current test building resources live under `core/buildings/data/`:
+- `blacksmith.tres`
+- `jeweler.tres`
+- `general_goods.tres`
+
+These are intended to be the reusable source pool for outpost generation.
+
+## Storefront behavior
+
+- Shared storefront UI is handled by `StorefrontOverlay`.
+- `BuildingData` contains `StorefrontItems`.
+- Storefront preview shows:
+  - selected item preview
+  - price above the purchase button
+  - purchase button disabled when funds are insufficient
+
+## Contract completion
+
+- `SaveNode.CompleteContract()` is the centralized transition for finishing a contract.
+- It uses `RunData.CurrentContract` and then:
+  - sets `RunData.CurrentBiome = contract.Biome`
+  - sets `RunData.CurrentLocation = contract.EndLocation`
+  - increments `RunData.ContractsCompleted`
+  - clears `RunData.CurrentContract`
+  - clears `RunData.OutpostBuildings`
+  - saves run data
+- Clearing `OutpostBuildings` is intentional so the next outpost is treated as new and regenerated.
+
+## Run overview rule
+
+- `New Run` button should only be visible when:
+  - there is no saved player, or
+  - `ContractsCompleted >= 1`
+
+This prevents fast rerolling before completing at least one contract.
+
+## Known local unrelated changes
+
+These were already dirty and not touched by the recent commits:
+- `scenes/components/outpost/buildingTemplate.tscn`
+- `scenes/main/main_menu/StartMenu.tscn`

--- a/autoload/save/SaveNode.cs
+++ b/autoload/save/SaveNode.cs
@@ -157,6 +157,23 @@ public partial class SaveNode : Node {
 		DeleteData(FileType.Settings);
 	}
 
+	public void CompleteContract() {
+		var contract = RunData?.CurrentContract;
+		if (contract == null) {
+			GD.PushWarning("CompleteContract called without an active contract.");
+			return;
+		}
+
+		GD.Print($"CompleteContract: moving to {contract.Biome} / {contract.EndLocation}.");
+		RunData.CurrentBiome = contract.Biome;
+		RunData.CurrentLocation = contract.EndLocation;
+		RunData.ContractsCompleted++;
+		RunData.CurrentContract = null;
+		RunData.OutpostBuildings = null;
+		GD.Print($"CompleteContract: contracts completed is now {RunData.ContractsCompleted}. Outpost buildings cleared.");
+		SaveRunData();
+	}
+
 	public void SaveAllData() {
 		SaveMetaData();
 		SaveRunData();

--- a/scenes/components/outpost/buildingTemplate.tscn
+++ b/scenes/components/outpost/buildingTemplate.tscn
@@ -2,11 +2,13 @@
 
 [ext_resource type="Texture2D" uid="uid://dsqb3fvddhg1s" path="res://assets/outpost/buildings/building_placeholder.svg" id="1_8rcmu"]
 [ext_resource type="Script" uid="uid://bt8a8igubvw8b" path="res://scenes/components/outpost/BuildingTemplate.cs" id="2_lm4d7"]
+[ext_resource type="Script" uid="uid://enkabhmf46kb" path="res://scenes/overlays/building/BuildingOverlayButtonData.cs" id="3_0o4qr"]
 [ext_resource type="Script" uid="uid://cd5blmxgvl3oe" path="res://scenes/components/outpost/BuildingData.cs" id="3_building_data"]
+[ext_resource type="Script" uid="uid://cesnllliaw0ql" path="res://core/items/ItemBase.cs" id="4_uxm22"]
+[ext_resource type="Theme" uid="uid://2us73xfo2hnd" path="res://assets/style/DefaultTheme.tres" id="6_i7hfi"]
 
 [sub_resource type="Resource" id="Resource_building_data"]
 script = ExtResource("3_building_data")
-LabelName = "Building"
 Description = "Interact with this building."
 OwnerText = "Welcome. What do you need?"
 BuildingTexture = ExtResource("1_8rcmu")
@@ -15,15 +17,15 @@ BuildingTexture = ExtResource("1_8rcmu")
 size = Vector2(64, 64)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_label_panel"]
+content_margin_left = 8.0
+content_margin_top = 3.0
+content_margin_right = 8.0
+content_margin_bottom = 3.0
 bg_color = Color(0.08, 0.07, 0.06, 0.82)
 corner_radius_top_left = 6
 corner_radius_top_right = 6
 corner_radius_bottom_right = 6
 corner_radius_bottom_left = 6
-content_margin_left = 8.0
-content_margin_top = 3.0
-content_margin_right = 8.0
-content_margin_bottom = 3.0
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_13jms"]
 radius = 61.03278
@@ -43,6 +45,7 @@ offset_top = -108.0
 offset_right = 48.0
 offset_bottom = -28.0
 mouse_filter = 2
+theme = ExtResource("6_i7hfi")
 
 [node name="Icon" type="TextureRect" parent="ClickPanel" unique_id=790543333]
 layout_mode = 1
@@ -70,7 +73,6 @@ theme_override_styles/panel = SubResource("StyleBoxFlat_label_panel")
 
 [node name="Label" type="Label" parent="ClickPanel/LabelPanel" unique_id=429572716]
 layout_mode = 2
-mouse_filter = 2
 text = "Building"
 horizontal_alignment = 1
 vertical_alignment = 1

--- a/scenes/main/character_select/RunOverview.cs
+++ b/scenes/main/character_select/RunOverview.cs
@@ -8,7 +8,17 @@ public partial class RunOverview : Control {
 	public override void _Ready() {
 		SetButtonScene("HBoxContainer/PanelButton/VBoxContainer/ContinueButton", OutpostScenePath);
 		SetButtonScene("HBoxContainer/PanelButton/VBoxContainer/NewRunButton", NewCharacterScenePath);
+		UpdateNewRunButtonVisibility();
 		SetButtonScene("BackButton", MainMenuScenePath);
+	}
+
+	private void UpdateNewRunButtonVisibility() {
+		var newRunButton = GetNodeOrNull<Button>("HBoxContainer/PanelButton/VBoxContainer/NewRunButton");
+		if (newRunButton == null)
+			return;
+
+		var runData = SaveNode.Get()?.RunData;
+		newRunButton.Visible = runData?.PlayerData == null || runData.ContractsCompleted >= 1;
 	}
 
 	private void SetButtonScene(string buttonPath, string scenePath) {

--- a/scenes/main/main_menu/StartMenu.tscn
+++ b/scenes/main/main_menu/StartMenu.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="Theme" uid="uid://2us73xfo2hnd" path="res://assets/style/DefaultTheme.tres" id="1_f84f2"]
 [ext_resource type="Script" uid="uid://c43vpjm3f8d4i" path="res://core/ui/ControlGotoScene.cs" id="2_2xbjv"]
 [ext_resource type="Script" uid="uid://dioyjiomklqq1" path="res://scenes/main/main_menu/StartMenu.cs" id="2_ks6tn"]
-[ext_resource type="PackedScene" path="res://scenes/main/character_select/RunOverview.tscn" id="3_fkdaq"]
+[ext_resource type="PackedScene" uid="uid://c1fhu7u3k6v5a" path="res://scenes/main/character_select/RunOverview.tscn" id="3_fkdaq"]
 [ext_resource type="Script" uid="uid://bn7lsfu8p7umr" path="res://core/ui/OpenOverlay.cs" id="3_w37gf"]
 [ext_resource type="PackedScene" path="res://scenes/overlays/main_menu/SettingsOverlay.tscn" id="4_settings"]
 [ext_resource type="PackedScene" uid="uid://bewk1qfwxhqaf" path="res://scenes/overlays/main_menu/CodexOverlay.tscn" id="5_codex"]


### PR DESCRIPTION
## Summary
- limit the New Run button so it only appears when there is no saved player or after at least one completed contract
- add `SaveNode.CompleteContract()` to apply contract destination state and clear cached outpost buildings for the next outpost
- add an `Ai-Summary` note documenting the current save, run, and outpost flow for future work