### PR TITLE
Add settings pages and smith compatibility placeholder

### DIFF
--- a/autoload/save/SaveNode.cs
+++ b/autoload/save/SaveNode.cs
@@ -16,10 +16,9 @@ public partial class SaveNode : Node {
 	public RunData RunData { get; set; }
 	public SettingsData SettingsData { get; set; }
 	public PlayerData[] StartCharacters { get; private set; } = Array.Empty<PlayerData>();
-	public bool HadPlayerDataOnLoad { get; private set; }
-	public PlayerData PlayerData => RunData.PlayerData;
-	public InventoryData InventoryData => PlayerData.InventoryData;
-	public EquipedItemsData EquipedItemsData => PlayerData.EquipedItems;
+	public PlayerData PlayerData => RunData?.PlayerData;
+	public InventoryData InventoryData => PlayerData?.InventoryData;
+	public EquipedItemsData EquipedItemsData => PlayerData?.EquipedItems;
 	public static SaveNode Get() => Engine.GetMainLoop() is SceneTree tree ? tree.Root.GetNode<SaveNode>("SaveNode") : throw new InvalidOperationException("SaveNode: Unable to find SaveNode in the scene tree. Ensure that SaveNode is added as a child of the root node and is named 'SaveNode'.");
 	public override void _Ready() {
 		if (DefaultMetaData == null || DefaultRunData == null || DefaultSettingsData == null) throw new InvalidOperationException("DefaultMetaData, DefaultRunData, and DefaultSettingsData must be assigned in the inspector.");
@@ -34,8 +33,6 @@ public partial class SaveNode : Node {
 		if (!FilesExist())
 			SaveAllData();
 
-		RunData.PlayerData ??= new PlayerData();
-		RunData.PlayerData.InventoryData ??= new InventoryData();
 		RefreshStartCharacters();
 		GD.Print("SaveNode is ready. MetaData, RunData, and SettingsData have been initialized.");
 	}
@@ -149,13 +146,30 @@ public partial class SaveNode : Node {
 	public bool RunDataExists() => FileExists(FileType.Run);
 	public bool SettingsDataExists() => FileExists(FileType.Settings);
 	public void SaveMetaData() => SaveData(MetaData, FileType.Meta);
-	public void SaveRunData() => SaveData(RunData, FileType.Run);
+	public void SaveRunData() {
+		if (RunData == null) {
+			DeleteRunData();
+			return;
+		}
+
+		SaveData(RunData, FileType.Run);
+	}
 	public void SaveSettingsData() => SaveData(SettingsData, FileType.Settings);
 
 	public void DeleteAllData() {
 		DeleteData(FileType.Meta);
 		DeleteData(FileType.Run);
 		DeleteData(FileType.Settings);
+	}
+
+	public void WipeAllData() {
+		GD.Print("WipeAllData: deleting all save files and restoring defaults.");
+		DeleteAllData();
+		MetaData = DuplicateSaveResource(DefaultMetaData);
+		RunData = null;
+		SettingsData = DuplicateSaveResource(DefaultSettingsData);
+		RefreshStartCharacters();
+		SaveAllData();
 	}
 
 	public void CompleteContract() {
@@ -177,7 +191,7 @@ public partial class SaveNode : Node {
 
 	public void WipeRun() {
 		GD.Print("WipeRun: resetting run data.");
-		RunData = new RunData();
+		RunData = DuplicateSaveResource(DefaultRunData);
 		MetaData ??= new MetaData();
 		MetaData.RunCount++;
 		GD.Print($"WipeRun: run count increased to {MetaData.RunCount}.");
@@ -191,17 +205,14 @@ public partial class SaveNode : Node {
 	}
 
 	public void LoadAllData() {
-		var loadedRunData = LoadData(FileType.Run) as RunData;
-		HadPlayerDataOnLoad = loadedRunData?.PlayerData != null;
-
 		MetaData = LoadData(FileType.Meta) as MetaData ?? DefaultMetaData;
-		RunData = loadedRunData ?? DefaultRunData;
+		RunData = LoadData(FileType.Run) as RunData;
 		SettingsData = LoadData(FileType.Settings) as SettingsData ?? DefaultSettingsData;
 
 		if (MetaData.IsFirstTimePlayer) GD.Print("First time player detected. Tutorial gameplay enabled.");
 
 		GD.Print(MetaData.ToString());
-		GD.Print(RunData.ToString());
+		GD.Print(RunData?.ToString() ?? "RunData: None");
 		GD.Print(SettingsData.ToString());
 	}
 
@@ -211,5 +222,9 @@ public partial class SaveNode : Node {
 		return FileAccess.FileExists(GetSavePath(FileType.Meta)) &&
 			   FileAccess.FileExists(GetSavePath(FileType.Run)) &&
 			   FileAccess.FileExists(GetSavePath(FileType.Settings));
+	}
+
+	private static T DuplicateSaveResource<T>(T resource) where T : Resource {
+		return resource?.Duplicate(true) as T;
 	}
 }

--- a/autoload/save/data/RunData.cs
+++ b/autoload/save/data/RunData.cs
@@ -7,7 +7,7 @@ namespace SaveData {
 	public partial class RunData : SaveResource {
 		[Export] public Biomes CurrentBiome { get; set; } = Biomes.GrasslandsA;
 		[Export] public Locations CurrentLocation { get; set; } = Locations.Village;
-		[Export] public PlayerData PlayerData { get; set; } = new PlayerData();
+		[Export] public PlayerData PlayerData { get; set; }
 		[Export] public Contract CurrentContract { get; set; } = null;
 		[Export] public Array<BuildingData> OutpostBuildings { get; set; }
 		[Export] public int ContractsCompleted { get; set; } = 0;

--- a/core/buildings/data/blacksmith.tres
+++ b/core/buildings/data/blacksmith.tres
@@ -1,8 +1,9 @@
-[gd_resource type="Resource" script_class="BuildingData" load_steps=8 format=3]
+[gd_resource type="Resource" script_class="BuildingData" load_steps=9 format=3]
 
 [ext_resource type="Script" uid="uid://cd5blmxgvl3oe" path="res://scenes/components/outpost/BuildingData.cs" id="1_building"]
 [ext_resource type="Script" uid="uid://enkabhmf46kb" path="res://scenes/overlays/building/BuildingOverlayButtonData.cs" id="2_button"]
 [ext_resource type="PackedScene" path="res://scenes/overlays/storefront/StorefrontOverlay.tscn" id="3_storefront"]
+[ext_resource type="PackedScene" path="res://scenes/overlays/building/SmithOverlay.tscn" id="4_smith"]
 [ext_resource type="Resource" path="res://core/items/data/iron_sword.tres" id="4_iron_sword"]
 [ext_resource type="Resource" path="res://core/items/data/health_potion.tres" id="5_health_potion"]
 [ext_resource type="Resource" path="res://core/items/data/leather_armor.tres" id="6_leather_armor"]
@@ -13,6 +14,7 @@ size = Vector2(64, 64)
 [sub_resource type="Resource" id="Resource_forge_button"]
 script = ExtResource("2_button")
 LabelName = "Forge"
+PathController = ExtResource("4_smith")
 
 [sub_resource type="Resource" id="Resource_shop_button"]
 script = ExtResource("2_button")

--- a/core/items/ItemBase.cs
+++ b/core/items/ItemBase.cs
@@ -12,6 +12,7 @@ public partial class ItemBase : Resource {
 	[Export] public int MaxStackSize { get; set; } = 1;
 	[Export] public int Cost { get; set; } = 0;
 	[Export] public string ItemID { get; set; }
+	[Export] public ItemOutpostCompatibilityData OutpostCompatibility { get; set; }
 	[Export] public bool IsConsumable { get; set; } = false;
 	[Export] public int UseCountMax { get; set; } = 0;
 	[Export] public int UseCountDefault { get; set; } = 0;
@@ -91,5 +92,13 @@ public partial class ItemBase : Resource {
 
 	public override string ToString() {
 		return $"{GetType().Name}(Name={ItemName}, Cost={Cost}, MaxStack={MaxStackSize}, Uses={UseCountCurrent}/{UseCountMax}, Condition={ConditionCurrent}/{ConditionMax})";
+	}
+
+	public bool HasCompatibility(OutpostBuildingCompatibility compatibility) {
+		return OutpostCompatibility != null && OutpostCompatibility.HasCompatibility(compatibility);
+	}
+
+	public bool IsCompatibleWith(OutpostBuildingCompatibility compatibility) {
+		return OutpostCompatibility == null || OutpostCompatibility.IsCompatibleWith(compatibility);
 	}
 }

--- a/core/items/ItemOutpostCompatibilityData.cs
+++ b/core/items/ItemOutpostCompatibilityData.cs
@@ -1,0 +1,18 @@
+#nullable enable
+
+using Godot;
+using Godot.Collections;
+using MyTypes;
+
+[GlobalClass]
+public partial class ItemOutpostCompatibilityData : Resource {
+	[Export] public Array<OutpostBuildingCompatibility> CompatibleBuildings { get; set; } = new();
+
+	public bool HasCompatibility(OutpostBuildingCompatibility compatibility) {
+		return CompatibleBuildings != null && CompatibleBuildings.Contains(compatibility);
+	}
+
+	public bool IsCompatibleWith(OutpostBuildingCompatibility compatibility) {
+		return CompatibleBuildings == null || CompatibleBuildings.Count == 0 || CompatibleBuildings.Contains(compatibility);
+	}
+}

--- a/core/items/ItemOutpostCompatibilityData.cs.uid
+++ b/core/items/ItemOutpostCompatibilityData.cs.uid
@@ -1,0 +1,1 @@
+uid://v14px24v4ful

--- a/core/items/data/arrow_bundle.tres
+++ b/core/items/data/arrow_bundle.tres
@@ -1,6 +1,11 @@
-[gd_resource type="Resource" script_class="ItemAmmo" load_steps=2 format=3]
+[gd_resource type="Resource" script_class="ItemAmmo" load_steps=3 format=3]
 
 [ext_resource type="Script" path="res://core/items/ItemAmmo.cs" id="1_item"]
+[ext_resource type="Script" path="res://core/items/ItemOutpostCompatibilityData.cs" id="2_compatibility"]
+
+[sub_resource type="Resource" id="Resource_compatibility"]
+script = ExtResource("2_compatibility")
+CompatibleBuildings = Array[int]([])
 
 [resource]
 script = ExtResource("1_item")
@@ -8,6 +13,7 @@ ItemName = "Arrow Bundle"
 MaxStackSize = 99
 Cost = 5
 ItemID = "item_arrow_bundle"
+OutpostCompatibility = SubResource("Resource_compatibility")
 IsConsumable = true
 UseCountMax = 99
 UseCountDefault = 20

--- a/core/items/data/health_potion.tres
+++ b/core/items/data/health_potion.tres
@@ -1,6 +1,11 @@
-[gd_resource type="Resource" script_class="ItemConsumable" load_steps=2 format=3]
+[gd_resource type="Resource" script_class="ItemConsumable" load_steps=3 format=3]
 
 [ext_resource type="Script" path="res://core/items/ItemConsumable.cs" id="1_item"]
+[ext_resource type="Script" path="res://core/items/ItemOutpostCompatibilityData.cs" id="2_compatibility"]
+
+[sub_resource type="Resource" id="Resource_compatibility"]
+script = ExtResource("2_compatibility")
+CompatibleBuildings = Array[int]([])
 
 [resource]
 script = ExtResource("1_item")
@@ -8,6 +13,7 @@ ItemName = "Health Potion"
 MaxStackSize = 10
 Cost = 8
 ItemID = "item_health_potion"
+OutpostCompatibility = SubResource("Resource_compatibility")
 IsConsumable = true
 UseCountMax = 10
 UseCountDefault = 1

--- a/core/items/data/hunter_bow.tres
+++ b/core/items/data/hunter_bow.tres
@@ -1,6 +1,11 @@
-[gd_resource type="Resource" script_class="ItemEquipable" load_steps=2 format=3]
+[gd_resource type="Resource" script_class="ItemEquipable" load_steps=3 format=3]
 
 [ext_resource type="Script" path="res://core/items/ItemEquipable.cs" id="1_item"]
+[ext_resource type="Script" path="res://core/items/ItemOutpostCompatibilityData.cs" id="2_compatibility"]
+
+[sub_resource type="Resource" id="Resource_compatibility"]
+script = ExtResource("2_compatibility")
+CompatibleBuildings = Array[int]([])
 
 [resource]
 script = ExtResource("1_item")
@@ -8,6 +13,7 @@ ItemName = "Hunter Bow"
 MaxStackSize = 1
 Cost = 35
 ItemID = "item_hunter_bow"
+OutpostCompatibility = SubResource("Resource_compatibility")
 HasCondition = true
 ConditionMax = 100
 ConditionDefault = 100

--- a/core/items/data/iron_sword.tres
+++ b/core/items/data/iron_sword.tres
@@ -1,6 +1,11 @@
-[gd_resource type="Resource" script_class="ItemEquipable" load_steps=2 format=3]
+[gd_resource type="Resource" script_class="ItemEquipable" load_steps=3 format=3]
 
 [ext_resource type="Script" path="res://core/items/ItemEquipable.cs" id="1_item"]
+[ext_resource type="Script" path="res://core/items/ItemOutpostCompatibilityData.cs" id="2_compatibility"]
+
+[sub_resource type="Resource" id="Resource_compatibility"]
+script = ExtResource("2_compatibility")
+CompatibleBuildings = Array[int]([2])
 
 [resource]
 script = ExtResource("1_item")
@@ -8,6 +13,7 @@ ItemName = "Iron Sword"
 MaxStackSize = 1
 Cost = 25
 ItemID = "item_iron_sword"
+OutpostCompatibility = SubResource("Resource_compatibility")
 HasCondition = true
 ConditionMax = 100
 ConditionDefault = 100

--- a/core/items/data/leather_armor.tres
+++ b/core/items/data/leather_armor.tres
@@ -1,6 +1,11 @@
-[gd_resource type="Resource" script_class="ItemArmor" load_steps=2 format=3]
+[gd_resource type="Resource" script_class="ItemArmor" load_steps=3 format=3]
 
 [ext_resource type="Script" path="res://core/items/ItemArmor.cs" id="1_item"]
+[ext_resource type="Script" path="res://core/items/ItemOutpostCompatibilityData.cs" id="2_compatibility"]
+
+[sub_resource type="Resource" id="Resource_compatibility"]
+script = ExtResource("2_compatibility")
+CompatibleBuildings = Array[int]([])
 
 [resource]
 script = ExtResource("1_item")
@@ -8,6 +13,7 @@ ItemName = "Leather Armor"
 MaxStackSize = 1
 Cost = 30
 ItemID = "item_leather_armor"
+OutpostCompatibility = SubResource("Resource_compatibility")
 HasCondition = true
 ConditionMax = 100
 ConditionDefault = 100

--- a/core/items/data/wolf_amulet.tres
+++ b/core/items/data/wolf_amulet.tres
@@ -1,6 +1,11 @@
-[gd_resource type="Resource" script_class="ItemAmulet" load_steps=2 format=3]
+[gd_resource type="Resource" script_class="ItemAmulet" load_steps=3 format=3]
 
 [ext_resource type="Script" path="res://core/items/ItemAmulet.cs" id="1_item"]
+[ext_resource type="Script" path="res://core/items/ItemOutpostCompatibilityData.cs" id="2_compatibility"]
+
+[sub_resource type="Resource" id="Resource_compatibility"]
+script = ExtResource("2_compatibility")
+CompatibleBuildings = Array[int]([])
 
 [resource]
 script = ExtResource("1_item")
@@ -8,3 +13,4 @@ ItemName = "Wolf Amulet"
 MaxStackSize = 1
 Cost = 50
 ItemID = "item_wolf_amulet"
+OutpostCompatibility = SubResource("Resource_compatibility")

--- a/core/types/Types.cs
+++ b/core/types/Types.cs
@@ -33,6 +33,17 @@ namespace MyTypes {
 		Enchanter,
 	}
 
+	public enum OutpostBuildingCompatibility {
+		None = 0,
+		General = 1,
+		Smith = 2,
+		Jewelry = 3,
+		Alchemy = 4,
+		Fletching = 5,
+		Arcana = 6,
+		Enchanting = 7,
+	}
+
 	public enum AmmoType {
 		None,
 		Arrow

--- a/core/ui/ControlGotoScene.cs
+++ b/core/ui/ControlGotoScene.cs
@@ -38,7 +38,7 @@ public partial class ControlGotoScene : Control {
 
 	private PackedScene GetSceneToLoad() {
 		var saveNode = SaveNode.Get();
-		if (!saveNode.HadPlayerDataOnLoad)
+		if (saveNode.PlayerData == null)
 			return ResourceLoader.Load<PackedScene>(NewCharacterScenePath);
 
 		return SceneToLoad;

--- a/scenes/components/panels/PanelGold.cs
+++ b/scenes/components/panels/PanelGold.cs
@@ -17,7 +17,7 @@ public partial class PanelGold : Control {
 		if (_label == null)
 			return;
 
-		UpdateGold(SaveNode.Get().RunData.Gold);
+		UpdateGold(SaveNode.Get()?.RunData?.Gold ?? 0);
 	}
 
 	private void OnGoldAmountChanged(int goldAmount) {

--- a/scenes/components/panels/PanelLocation.cs
+++ b/scenes/components/panels/PanelLocation.cs
@@ -12,13 +12,13 @@ public partial class PanelLocation : Control {
 	}
 
 	public void Update() {
-		var runData = SaveNode.Get().RunData;
+		var runData = SaveNode.Get()?.RunData;
 
 		if (_labelBiome != null)
-			_labelBiome.Text = FormatBiomeName(runData);
+			_labelBiome.Text = runData == null ? "Unknown" : FormatBiomeName(runData);
 
 		if (_labelLocationWave != null)
-			_labelLocationWave.Text = $"{runData.CurrentLocation} : W{runData.ContractsCompleted + 1}";
+			_labelLocationWave.Text = runData == null ? "Unknown : W0" : $"{runData.CurrentLocation} : W{runData.ContractsCompleted + 1}";
 	}
 
 	private static string FormatBiomeName(RunData runData) {

--- a/scenes/components/panels/PanelPlayerTop.cs
+++ b/scenes/components/panels/PanelPlayerTop.cs
@@ -11,8 +11,8 @@ public partial class PanelPlayerTop : Control {
 	}
 
 	public void Update() {
-		var runData = SaveNode.Get().RunData;
-		var playerData = runData.PlayerData;
+		var runData = SaveNode.Get()?.RunData;
+		var playerData = runData?.PlayerData;
 
 		if (_labelName != null)
 			_labelName.Text = string.IsNullOrWhiteSpace(playerData?.PlayerName) ? "Player" : playerData.PlayerName;

--- a/scenes/components/settings/SettingsDataPage.cs
+++ b/scenes/components/settings/SettingsDataPage.cs
@@ -1,0 +1,22 @@
+using Godot;
+
+public partial class SettingsDataPage : MarginContainer {
+	private Button _wipeAllDataButton;
+	private ConfirmationDialog _wipeConfirmationDialog;
+
+	public override void _Ready() {
+		_wipeAllDataButton = GetNode<Button>("Layout/WipeAllDataButton");
+		_wipeConfirmationDialog = GetNode<ConfirmationDialog>("WipeConfirmationDialog");
+
+		_wipeAllDataButton.Pressed += OnWipeAllDataPressed;
+		_wipeConfirmationDialog.Confirmed += OnWipeAllDataConfirmed;
+	}
+
+	private void OnWipeAllDataPressed() {
+		_wipeConfirmationDialog.PopupCentered();
+	}
+
+	private void OnWipeAllDataConfirmed() {
+		SaveNode.Get().WipeAllData();
+	}
+}

--- a/scenes/components/settings/SettingsDataPage.cs
+++ b/scenes/components/settings/SettingsDataPage.cs
@@ -1,6 +1,8 @@
 using Godot;
 
 public partial class SettingsDataPage : MarginContainer {
+	private const string StartMenuScenePath = "res://scenes/main/main_menu/StartMenu.tscn";
+
 	private Button _wipeAllDataButton;
 	private ConfirmationDialog _wipeConfirmationDialog;
 
@@ -18,5 +20,7 @@ public partial class SettingsDataPage : MarginContainer {
 
 	private void OnWipeAllDataConfirmed() {
 		SaveNode.Get().WipeAllData();
+		var startMenuScene = ResourceLoader.Load<PackedScene>(StartMenuScenePath);
+		GlobalOverlay.Get()?.ChangeRootScene(startMenuScene);
 	}
 }

--- a/scenes/components/settings/SettingsDataPage.cs.uid
+++ b/scenes/components/settings/SettingsDataPage.cs.uid
@@ -1,0 +1,1 @@
+uid://bo4mmblbnh3mn

--- a/scenes/components/settings/SettingsDataPage.tscn
+++ b/scenes/components/settings/SettingsDataPage.tscn
@@ -1,0 +1,46 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Theme" uid="uid://2us73xfo2hnd" path="res://assets/style/DefaultTheme.tres" id="1_theme"]
+[ext_resource type="Script" path="res://scenes/components/settings/SettingsDataPage.cs" id="2_script"]
+
+[node name="SettingsDataPage" type="MarginContainer"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_theme")
+script = ExtResource("2_script")
+theme_override_constants/margin_left = 16
+theme_override_constants/margin_top = 16
+theme_override_constants/margin_right = 16
+theme_override_constants/margin_bottom = 16
+
+[node name="Layout" type="VBoxContainer" parent="."]
+layout_mode = 2
+theme_override_constants/separation = 12
+
+[node name="Heading" type="Label" parent="Layout"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 24
+text = "Data"
+
+[node name="Description" type="Label" parent="Layout"]
+layout_mode = 2
+text = "Manage local save data."
+
+[node name="WipeAllDataButton" type="Button" parent="Layout"]
+custom_minimum_size = Vector2(0, 56)
+layout_mode = 2
+text = "Wipe All Data"
+
+[node name="Warning" type="Label" parent="Layout"]
+layout_mode = 2
+text = "This permanently removes all saved progress and settings."
+autowrap_mode = 3
+
+[node name="WipeConfirmationDialog" type="ConfirmationDialog" parent="."]
+title = "Wipe All Data"
+ok_button_text = "Wipe Data"
+dialog_text = "This will permanently delete all saved data. This cannot be undone. Continue?"

--- a/scenes/components/settings/SettingsSoundPage.tscn
+++ b/scenes/components/settings/SettingsSoundPage.tscn
@@ -1,0 +1,29 @@
+[gd_scene format=3]
+
+[ext_resource type="Theme" uid="uid://2us73xfo2hnd" path="res://assets/style/DefaultTheme.tres" id="1_theme"]
+
+[node name="SettingsSoundPage" type="MarginContainer"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_theme")
+theme_override_constants/margin_left = 16
+theme_override_constants/margin_top = 16
+theme_override_constants/margin_right = 16
+theme_override_constants/margin_bottom = 16
+
+[node name="Layout" type="VBoxContainer" parent="."]
+layout_mode = 2
+theme_override_constants/separation = 12
+
+[node name="Heading" type="Label" parent="Layout"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 24
+text = "Sound"
+
+[node name="Description" type="Label" parent="Layout"]
+layout_mode = 2
+text = "Sound settings page placeholder."

--- a/scenes/components/settings/SettingsVideoPage.tscn
+++ b/scenes/components/settings/SettingsVideoPage.tscn
@@ -1,0 +1,29 @@
+[gd_scene format=3]
+
+[ext_resource type="Theme" uid="uid://2us73xfo2hnd" path="res://assets/style/DefaultTheme.tres" id="1_theme"]
+
+[node name="SettingsVideoPage" type="MarginContainer"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_theme")
+theme_override_constants/margin_left = 16
+theme_override_constants/margin_top = 16
+theme_override_constants/margin_right = 16
+theme_override_constants/margin_bottom = 16
+
+[node name="Layout" type="VBoxContainer" parent="."]
+layout_mode = 2
+theme_override_constants/separation = 12
+
+[node name="Heading" type="Label" parent="Layout"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 24
+text = "Video"
+
+[node name="Description" type="Label" parent="Layout"]
+layout_mode = 2
+text = "Video settings page placeholder."

--- a/scenes/main/outpost/OutpostBuildings.cs
+++ b/scenes/main/outpost/OutpostBuildings.cs
@@ -13,6 +13,9 @@ public partial class OutpostBuildings : Node2D {
 
 	public override void _Ready() {
 		var saveNode = SaveNode.Get();
+		if (saveNode.RunData == null)
+			return;
+
 		var buildings = saveNode.RunData.OutpostBuildings;
 
 		if (buildings == null || buildings.Count != GetChildCount()) {

--- a/scenes/overlays/building/SmithOverlay.cs
+++ b/scenes/overlays/building/SmithOverlay.cs
@@ -1,0 +1,135 @@
+using Godot;
+using System.Linq;
+
+public partial class SmithOverlay : Control {
+	private const int ItemsPerPage = 8;
+
+	private GridContainer _itemGrid;
+	private Label _emptyLabel;
+	private TextureRect _previewIcon;
+	private Label _previewDetails;
+	private Button _selectButton;
+	private Button _previousPageButton;
+	private Button _nextPageButton;
+	private Label _pageLabel;
+	private readonly PlaceholderTexture2D _placeholderIcon = new() { Size = new Vector2I(64, 64) };
+	private ItemBase[] _items = System.Array.Empty<ItemBase>();
+	private ItemBase _selectedItem;
+	private int _currentPage;
+
+	public override void _Ready() {
+		_itemGrid = GetNode<GridContainer>("Content/ItemPanel/MarginContainer/ItemLayout/ItemGrid");
+		_emptyLabel = GetNode<Label>("Content/ItemPanel/MarginContainer/ItemLayout/EmptyLabel");
+		_previewIcon = GetNode<TextureRect>("Content/PreviewPanel/MarginContainer/PreviewLayout/PreviewIcon");
+		_previewDetails = GetNode<Label>("Content/PreviewPanel/MarginContainer/PreviewLayout/PreviewDetails");
+		_selectButton = GetNode<Button>("Content/PreviewPanel/MarginContainer/PreviewLayout/SelectButton");
+		_previousPageButton = GetNode<Button>("Content/PreviewPanel/MarginContainer/PreviewLayout/PageControls/PreviousPageButton");
+		_nextPageButton = GetNode<Button>("Content/PreviewPanel/MarginContainer/PreviewLayout/PageControls/NextPageButton");
+		_pageLabel = GetNode<Label>("Content/PreviewPanel/MarginContainer/PreviewLayout/PageControls/PageLabel");
+
+		_selectButton.Pressed += OnSelectPressed;
+		_previousPageButton.Pressed += ShowPreviousPage;
+		_nextPageButton.Pressed += ShowNextPage;
+
+		LoadItems();
+		Render();
+	}
+
+	private void LoadItems() {
+		_currentPage = 0;
+		_selectedItem = null;
+		_items = SaveNode.Get()?.InventoryData?.Items?
+			.Where(item => item != null && item.IsCompatibleWith(MyTypes.OutpostBuildingCompatibility.Smith))
+			.ToArray() ?? System.Array.Empty<ItemBase>();
+	}
+
+	private void Render() {
+		RenderItems();
+		RenderPreview();
+	}
+
+	private void RenderItems() {
+		foreach (var child in _itemGrid.GetChildren())
+			child.QueueFree();
+
+		var hasItems = _items.Length > 0;
+		_itemGrid.Visible = hasItems;
+		_emptyLabel.Visible = !hasItems;
+
+		if (!hasItems) {
+			_pageLabel.Visible = false;
+			_previousPageButton.Visible = false;
+			_nextPageButton.Visible = false;
+			return;
+		}
+
+		var pageCount = Mathf.Max(1, Mathf.CeilToInt(_items.Length / (float)ItemsPerPage));
+		_currentPage = Mathf.Clamp(_currentPage, 0, pageCount - 1);
+
+		foreach (var item in _items.Skip(_currentPage * ItemsPerPage).Take(ItemsPerPage)) {
+			_itemGrid.AddChild(CreateItemButton(item));
+		}
+
+		_pageLabel.Visible = true;
+		_previousPageButton.Visible = true;
+		_nextPageButton.Visible = true;
+		_previousPageButton.Disabled = _currentPage <= 0;
+		_nextPageButton.Disabled = _currentPage >= pageCount - 1;
+		_pageLabel.Text = $"Page {_currentPage + 1} / {pageCount}";
+	}
+
+	private Button CreateItemButton(ItemBase item) {
+		var button = new Button {
+			CustomMinimumSize = new Vector2(132, 92),
+			SizeFlagsHorizontal = SizeFlags.ExpandFill,
+			SizeFlagsVertical = SizeFlags.ExpandFill,
+			Text = item.ItemName,
+			Icon = item.Icon ?? _placeholderIcon,
+			IconAlignment = HorizontalAlignment.Center,
+			VerticalIconAlignment = VerticalAlignment.Top,
+			ExpandIcon = true,
+			ClipText = true,
+			AutowrapMode = TextServer.AutowrapMode.WordSmart
+		};
+
+		button.Pressed += () => SelectItem(item);
+		return button;
+	}
+
+	private void SelectItem(ItemBase item) {
+		_selectedItem = item;
+		RenderPreview();
+	}
+
+	private void RenderPreview() {
+		if (_selectedItem == null) {
+			_previewIcon.Texture = _placeholderIcon;
+			_previewDetails.Text = _items.Length == 0
+				? "No smith-compatible items found."
+				: "Select an item to test smith compatibility.";
+			_selectButton.Disabled = true;
+			return;
+		}
+
+		_previewIcon.Texture = _selectedItem.Icon ?? _placeholderIcon;
+		_previewDetails.Text = $"{_selectedItem.ItemName}\nCompatible with smith. Upgrade logic comes later.";
+		_selectButton.Disabled = false;
+	}
+
+	private void OnSelectPressed() {
+		if (_selectedItem == null)
+			return;
+
+		_previewDetails.Text = $"Selected {_selectedItem.ItemName}. Placeholder only.";
+	}
+
+	private void ShowPreviousPage() {
+		_currentPage--;
+		RenderItems();
+	}
+
+	private void ShowNextPage() {
+		_currentPage++;
+		RenderItems();
+	}
+}

--- a/scenes/overlays/building/SmithOverlay.cs.uid
+++ b/scenes/overlays/building/SmithOverlay.cs.uid
@@ -1,0 +1,1 @@
+uid://dqwl71kkbol6m

--- a/scenes/overlays/building/SmithOverlay.tscn
+++ b/scenes/overlays/building/SmithOverlay.tscn
@@ -1,0 +1,157 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Theme" uid="uid://2us73xfo2hnd" path="res://assets/style/DefaultTheme.tres" id="1_theme"]
+[ext_resource type="Script" path="res://scenes/overlays/building/SmithOverlay.cs" id="2_script"]
+[ext_resource type="Script" uid="uid://b5nexivgcopri" path="res://core/ui/CloseOverlay.cs" id="3_close"]
+
+[node name="SmithOverlay" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_theme")
+script = ExtResource("2_script")
+
+[node name="Panel" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.39308554, 0.3930855, 0.39308548, 1)
+
+[node name="Content" type="HBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 32.0
+offset_top = 96.0
+offset_right = -32.0
+offset_bottom = -32.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 24
+
+[node name="ItemPanel" type="PanelContainer" parent="Content"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="MarginContainer" type="MarginContainer" parent="Content/ItemPanel"]
+layout_mode = 2
+theme_override_constants/margin_left = 16
+theme_override_constants/margin_top = 16
+theme_override_constants/margin_right = 16
+theme_override_constants/margin_bottom = 16
+
+[node name="ItemLayout" type="VBoxContainer" parent="Content/ItemPanel/MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 12
+
+[node name="Title" type="Label" parent="Content/ItemPanel/MarginContainer/ItemLayout"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 32
+text = "Smith Items"
+horizontal_alignment = 1
+
+[node name="EmptyLabel" type="Label" parent="Content/ItemPanel/MarginContainer/ItemLayout"]
+layout_mode = 2
+text = "No smith-compatible items found."
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="ItemGrid" type="GridContainer" parent="Content/ItemPanel/MarginContainer/ItemLayout"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+columns = 2
+theme_override_constants/h_separation = 16
+theme_override_constants/v_separation = 16
+
+[node name="PreviewPanel" type="PanelContainer" parent="Content"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="MarginContainer" type="MarginContainer" parent="Content/PreviewPanel"]
+layout_mode = 2
+theme_override_constants/margin_left = 24
+theme_override_constants/margin_top = 24
+theme_override_constants/margin_right = 24
+theme_override_constants/margin_bottom = 24
+
+[node name="PreviewLayout" type="VBoxContainer" parent="Content/PreviewPanel/MarginContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 16
+
+[node name="Title" type="Label" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 36
+text = "Forge"
+
+[node name="PreviewIcon" type="TextureRect" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
+custom_minimum_size = Vector2(128, 128)
+layout_mode = 2
+size_flags_horizontal = 4
+expand_mode = 1
+stretch_mode = 5
+
+[node name="PreviewDetails" type="Label" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
+layout_mode = 2
+size_flags_vertical = 3
+text = "Select an item to test smith compatibility."
+autowrap_mode = 3
+
+[node name="SelectButton" type="Button" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
+custom_minimum_size = Vector2(0, 56)
+layout_mode = 2
+text = "Select"
+
+[node name="PageControls" type="HBoxContainer" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
+layout_mode = 2
+theme_override_constants/separation = 16
+alignment = 1
+
+[node name="PreviousPageButton" type="Button" parent="Content/PreviewPanel/MarginContainer/PreviewLayout/PageControls"]
+custom_minimum_size = Vector2(120, 56)
+layout_mode = 2
+text = "< Prev"
+
+[node name="PageLabel" type="Label" parent="Content/PreviewPanel/MarginContainer/PreviewLayout/PageControls"]
+custom_minimum_size = Vector2(160, 56)
+layout_mode = 2
+text = "Page 1 / 1"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="NextPageButton" type="Button" parent="Content/PreviewPanel/MarginContainer/PreviewLayout/PageControls"]
+custom_minimum_size = Vector2(120, 56)
+layout_mode = 2
+text = "Next >"
+
+[node name="CloseOverlay" type="Button" parent="." node_paths=PackedStringArray("CloseTarget")]
+custom_minimum_size = Vector2(56, 56)
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -80.0
+offset_top = 24.0
+offset_right = -24.0
+offset_bottom = 80.0
+grow_horizontal = 0
+modulate = Color(1, 0.15, 0.15, 1)
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_colors/font_hover_color = Color(1, 1, 1, 1)
+theme_override_colors/font_pressed_color = Color(1, 1, 1, 1)
+text = "X"
+script = ExtResource("3_close")
+CloseTarget = NodePath("..")
+CloseAllOverlayChildren = true
+metadata/_custom_type_script = "uid://b5nexivgcopri"

--- a/scenes/overlays/main_menu/SettingsOverlay.cs
+++ b/scenes/overlays/main_menu/SettingsOverlay.cs
@@ -1,0 +1,34 @@
+using Godot;
+
+public partial class SettingsOverlay : Control {
+	private Button _soundButton;
+	private Button _videoButton;
+	private Button _dataButton;
+	private Label _categoryTitle;
+	private Control _soundPage;
+	private Control _videoPage;
+	private Control _dataPage;
+
+	public override void _Ready() {
+		_soundButton = GetNode<Button>("Content/CategoryPanel/MarginContainer/CategoryLayout/CategoryButtons/SoundButton");
+		_videoButton = GetNode<Button>("Content/CategoryPanel/MarginContainer/CategoryLayout/CategoryButtons/VideoButton");
+		_dataButton = GetNode<Button>("Content/CategoryPanel/MarginContainer/CategoryLayout/CategoryButtons/DataButton");
+		_categoryTitle = GetNode<Label>("Content/RightPanel/MarginContainer/RightLayout/CategoryTitle");
+		_soundPage = GetNode<Control>("Content/RightPanel/MarginContainer/RightLayout/Pages/SoundPage");
+		_videoPage = GetNode<Control>("Content/RightPanel/MarginContainer/RightLayout/Pages/VideoPage");
+		_dataPage = GetNode<Control>("Content/RightPanel/MarginContainer/RightLayout/Pages/DataPage");
+
+		_soundButton.Pressed += () => SelectPage("Sound");
+		_videoButton.Pressed += () => SelectPage("Video");
+		_dataButton.Pressed += () => SelectPage("Data");
+
+		SelectPage("Sound");
+	}
+
+	private void SelectPage(string pageName) {
+		_categoryTitle.Text = pageName;
+		_soundPage.Visible = pageName == "Sound";
+		_videoPage.Visible = pageName == "Video";
+		_dataPage.Visible = pageName == "Data";
+	}
+}

--- a/scenes/overlays/main_menu/SettingsOverlay.cs.uid
+++ b/scenes/overlays/main_menu/SettingsOverlay.cs.uid
@@ -1,0 +1,1 @@
+uid://dhrcghbba6kxc

--- a/scenes/overlays/main_menu/SettingsOverlay.tscn
+++ b/scenes/overlays/main_menu/SettingsOverlay.tscn
@@ -1,7 +1,11 @@
-[gd_scene load_steps=3 format=3]
+[gd_scene load_steps=7 format=3]
 
 [ext_resource type="Theme" uid="uid://2us73xfo2hnd" path="res://assets/style/DefaultTheme.tres" id="1_settings_theme"]
 [ext_resource type="Script" uid="uid://b5nexivgcopri" path="res://core/ui/CloseOverlay.cs" id="2_settings_close"]
+[ext_resource type="Script" path="res://scenes/overlays/main_menu/SettingsOverlay.cs" id="3_settings_controller"]
+[ext_resource type="PackedScene" path="res://scenes/components/settings/SettingsSoundPage.tscn" id="4_sound_page"]
+[ext_resource type="PackedScene" path="res://scenes/components/settings/SettingsVideoPage.tscn" id="5_video_page"]
+[ext_resource type="PackedScene" path="res://scenes/components/settings/SettingsDataPage.tscn" id="6_data_page"]
 
 [node name="SettingsOverlay" type="Control"]
 layout_mode = 3
@@ -11,6 +15,7 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("1_settings_theme")
+script = ExtResource("3_settings_controller")
 
 [node name="Panel" type="ColorRect" parent="."]
 layout_mode = 1
@@ -20,6 +25,103 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 color = Color(0.39308554, 0.3930855, 0.39308548, 1)
+
+[node name="Content" type="HBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 32.0
+offset_top = 96.0
+offset_right = -32.0
+offset_bottom = -32.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 24
+
+[node name="CategoryPanel" type="PanelContainer" parent="Content"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="MarginContainer" type="MarginContainer" parent="Content/CategoryPanel"]
+layout_mode = 2
+theme_override_constants/margin_left = 16
+theme_override_constants/margin_top = 16
+theme_override_constants/margin_right = 16
+theme_override_constants/margin_bottom = 16
+
+[node name="CategoryLayout" type="VBoxContainer" parent="Content/CategoryPanel/MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 12
+
+[node name="Title" type="Label" parent="Content/CategoryPanel/MarginContainer/CategoryLayout"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 32
+text = "Categories"
+horizontal_alignment = 1
+
+[node name="CategoryButtons" type="VBoxContainer" parent="Content/CategoryPanel/MarginContainer/CategoryLayout"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 8
+
+[node name="SoundButton" type="Button" parent="Content/CategoryPanel/MarginContainer/CategoryLayout/CategoryButtons"]
+custom_minimum_size = Vector2(0, 64)
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Sound"
+
+[node name="VideoButton" type="Button" parent="Content/CategoryPanel/MarginContainer/CategoryLayout/CategoryButtons"]
+custom_minimum_size = Vector2(0, 64)
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Video"
+
+[node name="DataButton" type="Button" parent="Content/CategoryPanel/MarginContainer/CategoryLayout/CategoryButtons"]
+custom_minimum_size = Vector2(0, 64)
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Data"
+
+[node name="RightPanel" type="PanelContainer" parent="Content"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+size_flags_stretch_ratio = 2.0
+
+[node name="MarginContainer" type="MarginContainer" parent="Content/RightPanel"]
+layout_mode = 2
+theme_override_constants/margin_left = 24
+theme_override_constants/margin_top = 24
+theme_override_constants/margin_right = 24
+theme_override_constants/margin_bottom = 24
+
+[node name="RightLayout" type="VBoxContainer" parent="Content/RightPanel/MarginContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 16
+
+[node name="CategoryTitle" type="Label" parent="Content/RightPanel/MarginContainer/RightLayout"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 36
+text = "Sound"
+
+[node name="Pages" type="Control" parent="Content/RightPanel/MarginContainer/RightLayout"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="SoundPage" parent="Content/RightPanel/MarginContainer/RightLayout/Pages" instance=ExtResource("4_sound_page")]
+visible = false
+
+[node name="VideoPage" parent="Content/RightPanel/MarginContainer/RightLayout/Pages" instance=ExtResource("5_video_page")]
+visible = false
+
+[node name="DataPage" parent="Content/RightPanel/MarginContainer/RightLayout/Pages" instance=ExtResource("6_data_page")]
+visible = false
 
 [node name="CloseOverlay" type="Button" parent="." node_paths=PackedStringArray("CloseTarget")]
 custom_minimum_size = Vector2(56, 56)

--- a/scenes/overlays/storefront/StorefrontOverlay.cs
+++ b/scenes/overlays/storefront/StorefrontOverlay.cs
@@ -101,7 +101,7 @@ public partial class StorefrontOverlay : Control {
 
 	private bool CanPurchase(ItemBase item) {
 		var saveNode = SaveNode.Get();
-		return item != null && saveNode?.RunData != null && saveNode.RunData.Gold >= item.Cost;
+		return item != null && saveNode?.RunData != null && saveNode.InventoryData != null && saveNode.RunData.Gold >= item.Cost;
 	}
 
 	private void PurchaseSelectedItem() {
@@ -111,6 +111,9 @@ public partial class StorefrontOverlay : Control {
 		}
 
 		var saveNode = SaveNode.Get();
+		if (saveNode?.InventoryData == null)
+			return;
+
 		saveNode.RunData.Gold -= _selectedItem.Cost;
 		saveNode.InventoryData.AddItem(_selectedItem);
 		_buildingData.StorefrontItems.Remove(_selectedItem);


### PR DESCRIPTION
## Summary
- add a codex-style settings overlay with sound, video, and data pages, including a wipe-data confirmation flow that returns to start menu
- add an outpost item compatibility resource on items and seed current item data so only the sword is smith-compatible for now
- add a blacksmith forge placeholder overlay that lists only smith-compatible inventory items for testing the compatibility layer
- wrap generated outpost building state in `OutpostData`, load it from run data, generate and save it when missing, and add nested debug output for outpost/building save data

Closes #26