### PR TITLE
add outpost overlays and usertest UI fixes

### DIFF
--- a/Ai-Summary/save-run-outpost-context.md
+++ b/Ai-Summary/save-run-outpost-context.md
@@ -1,0 +1,85 @@
+# Save / Run / Outpost Context
+
+Updated on `smallfix` after the following commits:
+- `fe5c1ab` Limit new run button visibility
+- `ecb3266` Add contract completion run transition
+
+## SaveNode flow
+
+- `SaveNode.RunData` is the active run state.
+- `SaveNode.WipeRun()` is the central reset path for starting a new run.
+- `WipeRun()`:
+  - replaces `RunData` with a fresh `RunData`
+  - increments `MetaData.RunCount`
+  - saves metadata immediately
+
+## Player / inventory ownership
+
+- Inventory is intended to be player-owned, not run-owned.
+- `InventoryData` belongs on `PlayerData`.
+- `SaveNode.InventoryData` should resolve through `PlayerData.InventoryData`.
+- New character selection should:
+  - call `WipeRun()`
+  - assign the selected duplicated `PlayerData`
+  - initialize that player's inventory
+  - add duplicated starting item into that player inventory
+
+## Outpost generation
+
+- Outpost buildings are stored in `RunData.OutpostBuildings`.
+- The array is slot-based, not compacted:
+  - `null` means empty slot
+  - non-null `BuildingData` means that slot spawns a building
+- New outposts should generate a random count from `0..available`
+- Building types are selected from the configured resource pool without replacement.
+- Chosen buildings are placed into random slots without replacement.
+- If saved outpost data is missing or has the wrong slot count, it should be regenerated.
+
+Example layouts:
+- `E, E, E`
+- `E, B, C`
+- `A, E, B`
+
+## Building resources
+
+Current test building resources live under `core/buildings/data/`:
+- `blacksmith.tres`
+- `jeweler.tres`
+- `general_goods.tres`
+
+These are intended to be the reusable source pool for outpost generation.
+
+## Storefront behavior
+
+- Shared storefront UI is handled by `StorefrontOverlay`.
+- `BuildingData` contains `StorefrontItems`.
+- Storefront preview shows:
+  - selected item preview
+  - price above the purchase button
+  - purchase button disabled when funds are insufficient
+
+## Contract completion
+
+- `SaveNode.CompleteContract()` is the centralized transition for finishing a contract.
+- It uses `RunData.CurrentContract` and then:
+  - sets `RunData.CurrentBiome = contract.Biome`
+  - sets `RunData.CurrentLocation = contract.EndLocation`
+  - increments `RunData.ContractsCompleted`
+  - clears `RunData.CurrentContract`
+  - clears `RunData.OutpostBuildings`
+  - saves run data
+- Clearing `OutpostBuildings` is intentional so the next outpost is treated as new and regenerated.
+
+## Run overview rule
+
+- `New Run` button should only be visible when:
+  - there is no saved player, or
+  - `ContractsCompleted >= 1`
+
+This prevents fast rerolling before completing at least one contract.
+
+## Known local unrelated changes
+
+These were already dirty and not touched by the recent commits:
+- `scenes/components/outpost/buildingTemplate.tscn`
+- `scenes/main/main_menu/StartMenu.tscn`

--- a/README.md
+++ b/README.md
@@ -77,6 +77,49 @@ Start -> Choose Path -> Fight -> Upgrade -> Boss -> Reward -> Repeat
 - Shared combat, item, and progression systems in reusable C# code
 - Autoload-based global systems for save data, overlays, and signals
 
+## Character Visual Structure Plan
+
+<details>
+<summary>Show Structure Plan</summary>
+
+Planned ingame character visuals should use a loose procedural `Node2D` puppet instead of starting with a bone/skeleton setup.
+
+Recommended structure:
+
+- gameplay root stays on `CharacterBody2D`
+- visuals live under a separate `VisualRoot`
+- body parts use separate nodes such as:
+- `Body`
+- `Head`
+- `LeftArmPivot`
+- `RightArmPivot`
+- `LeftLegPivot`
+- `RightLegPivot`
+
+Animation direction:
+
+- use math-driven motion first
+- walking bob with `sin`
+- arm and leg swing from movement speed
+- body tilt from movement direction
+- smoothing with `lerp` / `lerp_angle`
+
+Equipment direction:
+
+- weapons and armor should attach to body-part nodes
+- armor should support separate visual pieces where needed
+- do not assume one static player sprite for all equipment states
+
+Art direction for reuse:
+
+- use the same SVG source art for inventory and ingame visuals where possible
+- treat SVG as source art, then use imported `Texture2D` assets in Godot
+- keep one visual language across inventory icons, held items, and armor visuals
+
+This is intended to keep the character dynamic, lightweight to animate, and easy to extend with armor and weapon visuals later.
+
+</details>
+
 ## Project Status
 
 - Core combat and data models are in place

--- a/assets/shaders/PopupBlurBackdrop.gdshader
+++ b/assets/shaders/PopupBlurBackdrop.gdshader
@@ -1,7 +1,7 @@
 shader_type canvas_item;
 
 uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_linear_mipmap;
-uniform float blur_amount : hint_range(0.0, 4.0) = 2.0;
+uniform float blur_amount : hint_range(0.0, 4.0) = 3.0;
 uniform vec4 overlay_color : source_color = vec4(0.08, 0.08, 0.10, 0.30);
 
 void fragment() {

--- a/assets/shaders/PopupBlurBackdrop.gdshader
+++ b/assets/shaders/PopupBlurBackdrop.gdshader
@@ -1,0 +1,10 @@
+shader_type canvas_item;
+
+uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_linear_mipmap;
+uniform float blur_amount : hint_range(0.0, 4.0) = 2.0;
+uniform vec4 overlay_color : source_color = vec4(0.08, 0.08, 0.10, 0.30);
+
+void fragment() {
+	vec4 blurred = textureLod(screen_texture, SCREEN_UV, blur_amount);
+	COLOR = vec4(mix(blurred.rgb, overlay_color.rgb, overlay_color.a), 1.0);
+}

--- a/autoload/overlay/GlobalOverlay.cs
+++ b/autoload/overlay/GlobalOverlay.cs
@@ -47,6 +47,7 @@ public partial class GlobalOverlay : CanvasLayer {
 
 		EnsurePopupBlurBackdrop();
 		CloseInfoPopup();
+		MoveChild(_popupBlurBackdrop, GetChildCount() - 1);
 
 		_activeInfoPopup = InfoPopupPanelScene.Instantiate<InfoPopupPanel>();
 		_popupBlurBackdrop.Visible = true;

--- a/autoload/overlay/GlobalOverlay.cs
+++ b/autoload/overlay/GlobalOverlay.cs
@@ -1,11 +1,35 @@
 using Godot;
 
 public partial class GlobalOverlay : CanvasLayer {
-	public int OverlayCount => GetChildCount();
+	private const string PopupBlurBackdropName = "PopupBlurBackdrop";
+	private const string BlurShaderPath = "res://assets/shaders/PopupBlurBackdrop.gdshader";
+	private const string InfoPopupPanelScenePath = "res://scenes/components/panels/InfoPopupPanel.tscn";
+	private static readonly Shader BlurShader = ResourceLoader.Load<Shader>(BlurShaderPath);
+	private static readonly PackedScene InfoPopupPanelScene = ResourceLoader.Load<PackedScene>(InfoPopupPanelScenePath);
+	private ColorRect _popupBlurBackdrop;
+	private InfoPopupPanel _activeInfoPopup;
+
+	public int OverlayCount {
+		get {
+			var count = 0;
+			foreach (Node child in GetChildren()) {
+				if (child == _popupBlurBackdrop || child == _activeInfoPopup)
+					continue;
+
+				count++;
+			}
+
+			return count;
+		}
+	}
 
 	public static GlobalOverlay Get() {
 		var sceneTree = Engine.GetMainLoop() as SceneTree;
 		return sceneTree?.Root?.GetNodeOrNull<GlobalOverlay>("/root/GlobalOverlay");
+	}
+
+	public override void _Ready() {
+		EnsurePopupBlurBackdrop();
 	}
 
 	public void AddOverlay(PackedScene overlayScene) {
@@ -17,15 +41,43 @@ public partial class GlobalOverlay : CanvasLayer {
 		AddChild(overlayScene.Instantiate());
 	}
 
-	public void CloseTopOverlay() {
-		var childCount = GetChildCount();
-		if (childCount == 0) return;
+	public void ShowBlurredPopup(string title, string richText, Texture2D image = null) {
+		if (InfoPopupPanelScene == null)
+			return;
 
-		GetChild(childCount - 1).QueueFree();
+		EnsurePopupBlurBackdrop();
+		CloseInfoPopup();
+
+		_activeInfoPopup = InfoPopupPanelScene.Instantiate<InfoPopupPanel>();
+		_popupBlurBackdrop.Visible = true;
+		AddChild(_activeInfoPopup);
+		_activeInfoPopup.ShowContent(title, richText, image);
+		_activeInfoPopup.Closed += OnInfoPopupClosed;
+	}
+
+	public void CloseTopOverlay() {
+		if (GodotObject.IsInstanceValid(_activeInfoPopup)) {
+			CloseInfoPopup();
+			return;
+		}
+
+		for (var i = GetChildCount() - 1; i >= 0; i--) {
+			var child = GetChild(i);
+			if (child == _popupBlurBackdrop)
+				continue;
+
+			child.QueueFree();
+			return;
+		}
 	}
 
 	public void CloseAllOverlays() {
+		CloseInfoPopup();
+
 		foreach (Node child in GetChildren()) {
+			if (child == _popupBlurBackdrop)
+				continue;
+
 			child.QueueFree();
 		}
 	}
@@ -45,5 +97,46 @@ public partial class GlobalOverlay : CanvasLayer {
 		}
 
 		return sceneTree.ChangeSceneToPacked(scene);
+	}
+
+	private void EnsurePopupBlurBackdrop() {
+		if (GodotObject.IsInstanceValid(_popupBlurBackdrop))
+			return;
+
+		_popupBlurBackdrop = new ColorRect {
+			Name = PopupBlurBackdropName,
+			MouseFilter = Control.MouseFilterEnum.Stop,
+			Color = Colors.White,
+			Visible = false
+		};
+		_popupBlurBackdrop.SetAnchorsPreset(Control.LayoutPreset.FullRect);
+		_popupBlurBackdrop.OffsetLeft = 0.0f;
+		_popupBlurBackdrop.OffsetTop = 0.0f;
+		_popupBlurBackdrop.OffsetRight = 0.0f;
+		_popupBlurBackdrop.OffsetBottom = 0.0f;
+
+		if (BlurShader != null) {
+			_popupBlurBackdrop.Material = new ShaderMaterial {
+				Shader = BlurShader
+			};
+		}
+
+		AddChild(_popupBlurBackdrop);
+		MoveChild(_popupBlurBackdrop, 0);
+	}
+
+	private void OnInfoPopupClosed() {
+		CloseInfoPopup();
+	}
+
+	private void CloseInfoPopup() {
+		if (GodotObject.IsInstanceValid(_activeInfoPopup)) {
+			_activeInfoPopup.Closed -= OnInfoPopupClosed;
+			_activeInfoPopup.QueueFree();
+			_activeInfoPopup = null;
+		}
+
+		if (GodotObject.IsInstanceValid(_popupBlurBackdrop))
+			_popupBlurBackdrop.Visible = false;
 	}
 }

--- a/autoload/save/SaveNode.cs
+++ b/autoload/save/SaveNode.cs
@@ -50,6 +50,7 @@ public partial class SaveNode : Node {
 		return new PlayerData {
 			PlayerName = CharacterNames.GetRandomName(random),
 			StartingItem = StartingItems.GetRandomItem(random),
+			StartingTotalSkillXp = skills.GetTotalXp(),
 			Skills = skills
 		};
 	}

--- a/autoload/save/SaveNode.cs
+++ b/autoload/save/SaveNode.cs
@@ -18,7 +18,7 @@ public partial class SaveNode : Node {
 	public PlayerData[] StartCharacters { get; private set; } = Array.Empty<PlayerData>();
 	public bool HadPlayerDataOnLoad { get; private set; }
 	public PlayerData PlayerData => RunData.PlayerData;
-	public InventoryData InventoryData => RunData.InventoryData;
+	public InventoryData InventoryData => PlayerData.InventoryData;
 	public EquipedItemsData EquipedItemsData => PlayerData.EquipedItems;
 	public static SaveNode Get() => Engine.GetMainLoop() is SceneTree tree ? tree.Root.GetNode<SaveNode>("SaveNode") : throw new InvalidOperationException("SaveNode: Unable to find SaveNode in the scene tree. Ensure that SaveNode is added as a child of the root node and is named 'SaveNode'.");
 	public override void _Ready() {
@@ -35,6 +35,7 @@ public partial class SaveNode : Node {
 			SaveAllData();
 
 		RunData.PlayerData ??= new PlayerData();
+		RunData.PlayerData.InventoryData ??= new InventoryData();
 		RefreshStartCharacters();
 		GD.Print("SaveNode is ready. MetaData, RunData, and SettingsData have been initialized.");
 	}
@@ -158,9 +159,11 @@ public partial class SaveNode : Node {
 	}
 
 	public void WipeRun() {
+		GD.Print("WipeRun: resetting run data.");
 		RunData = new RunData();
 		MetaData ??= new MetaData();
 		MetaData.RunCount++;
+		GD.Print($"WipeRun: run count increased to {MetaData.RunCount}.");
 		SaveMetaData();
 	}
 

--- a/autoload/save/SaveNode.cs
+++ b/autoload/save/SaveNode.cs
@@ -157,6 +157,23 @@ public partial class SaveNode : Node {
 		DeleteData(FileType.Settings);
 	}
 
+	public void CompleteContract() {
+		var contract = RunData?.CurrentContract;
+		if (contract == null) {
+			GD.PushWarning("CompleteContract called without an active contract.");
+			return;
+		}
+
+		GD.Print($"CompleteContract: moving to {contract.Biome} / {contract.EndLocation}.");
+		RunData.CurrentBiome = contract.Biome;
+		RunData.CurrentLocation = contract.EndLocation;
+		RunData.ContractsCompleted++;
+		RunData.CurrentContract = null;
+		RunData.OutpostBuildings = null;
+		GD.Print($"CompleteContract: contracts completed is now {RunData.ContractsCompleted}. Outpost buildings cleared.");
+		SaveRunData();
+	}
+
 	public void SaveAllData() {
 		SaveMetaData();
 		SaveRunData();

--- a/autoload/save/SaveNode.cs
+++ b/autoload/save/SaveNode.cs
@@ -184,7 +184,7 @@ public partial class SaveNode : Node {
 		RunData.CurrentLocation = contract.EndLocation;
 		RunData.ContractsCompleted++;
 		RunData.CurrentContract = null;
-		RunData.OutpostBuildings = null;
+		RunData.OutpostData = null;
 		GD.Print($"CompleteContract: contracts completed is now {RunData.ContractsCompleted}. Outpost buildings cleared.");
 		SaveRunData();
 	}

--- a/autoload/save/SaveNode.cs
+++ b/autoload/save/SaveNode.cs
@@ -29,6 +29,7 @@ public partial class SaveNode : Node {
 	public void ExecuteReady() {
 		DirAccess.MakeDirRecursiveAbsolute(SavePath);
 		LoadAllData();
+		ApplySettings();
 
 		if (!FilesExist())
 			SaveAllData();
@@ -168,6 +169,7 @@ public partial class SaveNode : Node {
 		MetaData = DuplicateSaveResource(DefaultMetaData);
 		RunData = null;
 		SettingsData = DuplicateSaveResource(DefaultSettingsData);
+		ApplySettings();
 		RefreshStartCharacters();
 		SaveAllData();
 	}
@@ -226,5 +228,24 @@ public partial class SaveNode : Node {
 
 	private static T DuplicateSaveResource<T>(T resource) where T : Resource {
 		return resource?.Duplicate(true) as T;
+	}
+
+	public void ApplySettings() {
+		if (SettingsData == null)
+			return;
+
+		ApplyBusSettings("SFX", SettingsData.SfxVolumePercent, SettingsData.SfxEnabled);
+		ApplyBusSettings("Music", SettingsData.MusicVolumePercent, SettingsData.MusicEnabled);
+	}
+
+	private static void ApplyBusSettings(string busName, float volumePercent, bool enabled) {
+		var busIndex = AudioServer.GetBusIndex(busName);
+		if (busIndex < 0) {
+			GD.PushWarning($"SaveNode: Audio bus '{busName}' was not found.");
+			return;
+		}
+
+		AudioServer.SetBusMute(busIndex, !enabled);
+		AudioServer.SetBusVolumeDb(busIndex, Mathf.LinearToDb(Mathf.Clamp(volumePercent, 0.0f, 100.0f) / 100.0f));
 	}
 }

--- a/autoload/save/SaveNode.cs
+++ b/autoload/save/SaveNode.cs
@@ -157,6 +157,13 @@ public partial class SaveNode : Node {
 		DeleteData(FileType.Settings);
 	}
 
+	public void WipeRun() {
+		RunData = new RunData();
+		MetaData ??= new MetaData();
+		MetaData.RunCount++;
+		SaveMetaData();
+	}
+
 	public void SaveAllData() {
 		SaveMetaData();
 		SaveRunData();

--- a/autoload/save/SaveNode.cs
+++ b/autoload/save/SaveNode.cs
@@ -16,10 +16,9 @@ public partial class SaveNode : Node {
 	public RunData RunData { get; set; }
 	public SettingsData SettingsData { get; set; }
 	public PlayerData[] StartCharacters { get; private set; } = Array.Empty<PlayerData>();
-	public bool HadPlayerDataOnLoad { get; private set; }
-	public PlayerData PlayerData => RunData.PlayerData;
-	public InventoryData InventoryData => PlayerData.InventoryData;
-	public EquipedItemsData EquipedItemsData => PlayerData.EquipedItems;
+	public PlayerData PlayerData => RunData?.PlayerData;
+	public InventoryData InventoryData => PlayerData?.InventoryData;
+	public EquipedItemsData EquipedItemsData => PlayerData?.EquipedItems;
 	public static SaveNode Get() => Engine.GetMainLoop() is SceneTree tree ? tree.Root.GetNode<SaveNode>("SaveNode") : throw new InvalidOperationException("SaveNode: Unable to find SaveNode in the scene tree. Ensure that SaveNode is added as a child of the root node and is named 'SaveNode'.");
 	public override void _Ready() {
 		if (DefaultMetaData == null || DefaultRunData == null || DefaultSettingsData == null) throw new InvalidOperationException("DefaultMetaData, DefaultRunData, and DefaultSettingsData must be assigned in the inspector.");
@@ -34,8 +33,6 @@ public partial class SaveNode : Node {
 		if (!FilesExist())
 			SaveAllData();
 
-		RunData.PlayerData ??= new PlayerData();
-		RunData.PlayerData.InventoryData ??= new InventoryData();
 		RefreshStartCharacters();
 		GD.Print("SaveNode is ready. MetaData, RunData, and SettingsData have been initialized.");
 	}
@@ -149,13 +146,30 @@ public partial class SaveNode : Node {
 	public bool RunDataExists() => FileExists(FileType.Run);
 	public bool SettingsDataExists() => FileExists(FileType.Settings);
 	public void SaveMetaData() => SaveData(MetaData, FileType.Meta);
-	public void SaveRunData() => SaveData(RunData, FileType.Run);
+	public void SaveRunData() {
+		if (RunData == null) {
+			DeleteRunData();
+			return;
+		}
+
+		SaveData(RunData, FileType.Run);
+	}
 	public void SaveSettingsData() => SaveData(SettingsData, FileType.Settings);
 
 	public void DeleteAllData() {
 		DeleteData(FileType.Meta);
 		DeleteData(FileType.Run);
 		DeleteData(FileType.Settings);
+	}
+
+	public void WipeAllData() {
+		GD.Print("WipeAllData: deleting all save files and restoring defaults.");
+		DeleteAllData();
+		MetaData = DuplicateSaveResource(DefaultMetaData);
+		RunData = null;
+		SettingsData = DuplicateSaveResource(DefaultSettingsData);
+		RefreshStartCharacters();
+		SaveAllData();
 	}
 
 	public void CompleteContract() {
@@ -177,7 +191,7 @@ public partial class SaveNode : Node {
 
 	public void WipeRun() {
 		GD.Print("WipeRun: resetting run data.");
-		RunData = new RunData();
+		RunData = DuplicateSaveResource(DefaultRunData);
 		MetaData ??= new MetaData();
 		MetaData.RunCount++;
 		GD.Print($"WipeRun: run count increased to {MetaData.RunCount}.");
@@ -191,17 +205,14 @@ public partial class SaveNode : Node {
 	}
 
 	public void LoadAllData() {
-		var loadedRunData = LoadData(FileType.Run) as RunData;
-		HadPlayerDataOnLoad = loadedRunData?.PlayerData != null;
-
 		MetaData = LoadData(FileType.Meta) as MetaData ?? DefaultMetaData;
-		RunData = loadedRunData ?? DefaultRunData;
+		RunData = LoadData(FileType.Run) as RunData;
 		SettingsData = LoadData(FileType.Settings) as SettingsData ?? DefaultSettingsData;
 
 		if (MetaData.IsFirstTimePlayer) GD.Print("First time player detected. Tutorial gameplay enabled.");
 
 		GD.Print(MetaData.ToString());
-		GD.Print(RunData.ToString());
+		GD.Print(RunData?.ToString() ?? "RunData: None");
 		GD.Print(SettingsData.ToString());
 	}
 
@@ -211,5 +222,9 @@ public partial class SaveNode : Node {
 		return FileAccess.FileExists(GetSavePath(FileType.Meta)) &&
 			   FileAccess.FileExists(GetSavePath(FileType.Run)) &&
 			   FileAccess.FileExists(GetSavePath(FileType.Settings));
+	}
+
+	private static T DuplicateSaveResource<T>(T resource) where T : Resource {
+		return resource?.Duplicate(true) as T;
 	}
 }

--- a/autoload/save/data/MetaData.cs
+++ b/autoload/save/data/MetaData.cs
@@ -9,9 +9,10 @@ namespace SaveData {
 		[Export] public bool GemBlueCollected { get; set; } = false;
 		[ExportGroup("Run Data")]
 		[Export] public int RunCount { get; set; } = 0;
+		[Export] public bool HasSeenOutpostIntro { get; set; } = false;
 		public bool IsFirstTimePlayer => RunCount == 0;
 		public override string ToString() {
-			return $"MetaData: RunCount={RunCount}, IsFirstTimePlayer={IsFirstTimePlayer}, CollectedGems=[Red={GemRedCollected}, Green={GemGreenCollected}, Blue={GemBlueCollected}]";
+			return $"MetaData: RunCount={RunCount}, IsFirstTimePlayer={IsFirstTimePlayer}, HasSeenOutpostIntro={HasSeenOutpostIntro}, CollectedGems=[Red={GemRedCollected}, Green={GemGreenCollected}, Blue={GemBlueCollected}]";
 		}
 	}
 

--- a/autoload/save/data/OutpostData.cs
+++ b/autoload/save/data/OutpostData.cs
@@ -1,13 +1,29 @@
 using Godot;
 using Godot.Collections;
 
+
 namespace SaveData {
 	[GlobalClass]
 	public partial class OutpostData : SaveResource {
 		[Export] public Array<BuildingData> Buildings { get; set; }
 
 		public override string ToString() {
-			return $"OutpostData: Buildings={Buildings?.Count ?? 0}";
+			return $"OutpostData:\n  Buildings={FormatBuildings(Buildings)}";
+		}
+
+		private static string FormatBuildings(Array<BuildingData> buildings) {
+			if (buildings == null || buildings.Count == 0)
+				return "[]";
+
+			var result = "[\n";
+			for (var i = 0; i < buildings.Count; i++) {
+				if (i > 0)
+					result += ",\n";
+
+				result += $"    Slot {i}: {buildings[i]?.ToString() ?? "None"}";
+			}
+
+			return result + "\n  ]";
 		}
 	}
 }

--- a/autoload/save/data/OutpostData.cs
+++ b/autoload/save/data/OutpostData.cs
@@ -1,0 +1,13 @@
+using Godot;
+using Godot.Collections;
+
+namespace SaveData {
+	[GlobalClass]
+	public partial class OutpostData : SaveResource {
+		[Export] public Array<BuildingData> Buildings { get; set; }
+
+		public override string ToString() {
+			return $"OutpostData: Buildings={Buildings?.Count ?? 0}";
+		}
+	}
+}

--- a/autoload/save/data/OutpostData.cs.uid
+++ b/autoload/save/data/OutpostData.cs.uid
@@ -1,0 +1,1 @@
+uid://cu4ms5j6baddh

--- a/autoload/save/data/PlayerData.cs
+++ b/autoload/save/data/PlayerData.cs
@@ -6,9 +6,16 @@ public partial class PlayerData : Resource {
 	[Export] public InventoryData InventoryData { get; set; } = new();
 	[Export] public EquipedItemsData EquipedItems { get; set; } = new();
 	[Export] public PlayerSkillData Skills { get; set; } = new();
+	[Export] public int StartingTotalSkillXp { get; set; } = 0;
 	[Export] public ItemBase StartingItem { get; set; }
 
+	public int GetCurrentRunLevel() {
+		var currentTotalXp = Skills?.GetTotalXp() ?? 0;
+		var earnedXp = Mathf.Max(0, currentTotalXp - StartingTotalSkillXp);
+		return PlayerSkillData.GetLevelFromXp(earnedXp);
+	}
+
 	public override string ToString() {
-		return $"PlayerData:\n    PlayerName={PlayerName}\n    InventoryData={InventoryData}\n    EquipedItems={EquipedItems}\n    Skills={Skills}\n    StartingItem={StartingItem}";
+		return $"PlayerData:\n    PlayerName={PlayerName}\n    InventoryData={InventoryData}\n    EquipedItems={EquipedItems}\n    Skills={Skills}\n    StartingTotalSkillXp={StartingTotalSkillXp}\n    StartingItem={StartingItem}";
 	}
 }

--- a/autoload/save/data/PlayerData.cs
+++ b/autoload/save/data/PlayerData.cs
@@ -3,11 +3,12 @@ using Godot;
 [GlobalClass]
 public partial class PlayerData : Resource {
 	[Export] public string PlayerName { get; set; } = "Player";
+	[Export] public InventoryData InventoryData { get; set; } = new();
 	[Export] public EquipedItemsData EquipedItems { get; set; } = new();
 	[Export] public PlayerSkillData Skills { get; set; } = new();
 	[Export] public ItemBase StartingItem { get; set; }
 
 	public override string ToString() {
-		return $"PlayerData:\n    PlayerName={PlayerName}\n    EquipedItems={EquipedItems}\n    Skills={Skills}\n    StartingItem={StartingItem}";
+		return $"PlayerData:\n    PlayerName={PlayerName}\n    InventoryData={InventoryData}\n    EquipedItems={EquipedItems}\n    Skills={Skills}\n    StartingItem={StartingItem}";
 	}
 }

--- a/autoload/save/data/PlayerSkillData.cs
+++ b/autoload/save/data/PlayerSkillData.cs
@@ -17,7 +17,11 @@ public partial class PlayerSkillData : Resource {
 	[Export] public int VitalityXp { get; set; } = 0;
 
 	public int GetLevel(int currentXp) {
-		return (currentXp / XpPerLevel) + 1;
+		return GetLevelFromXp(currentXp);
+	}
+
+	public static int GetLevelFromXp(int currentXp) {
+		return (Mathf.Max(0, currentXp) / XpPerLevel) + 1;
 	}
 
 	public int GetXp(PlayerSkillType skillType) {
@@ -52,6 +56,10 @@ public partial class PlayerSkillData : Resource {
 
 	public int GetTotalLevel() {
 		return GetStrengthLevel() + GetAgilityLevel() + GetArcanaLevel() + GetVitalityLevel();
+	}
+
+	public int GetTotalXp() {
+		return StrengthXp + AgilityXp + ArcanaXp + VitalityXp;
 	}
 
 	public override string ToString() {

--- a/autoload/save/data/RunData.cs
+++ b/autoload/save/data/RunData.cs
@@ -1,4 +1,5 @@
 using Godot;
+using Godot.Collections;
 using MyTypes;
 
 namespace SaveData {
@@ -9,6 +10,7 @@ namespace SaveData {
 		[Export] public PlayerData PlayerData { get; set; } = new PlayerData();
 		[Export] public Contract CurrentContract { get; set; } = null;
 		[Export] public InventoryData InventoryData { get; set; } = new InventoryData();
+		[Export] public Array<BuildingData> OutpostBuildings { get; set; }
 		[Export] public int ContractsCompleted { get; set; } = 0;
 		[Export] public int Gold { get; set; } = 100;
 		public override string ToString() {
@@ -18,6 +20,7 @@ namespace SaveData {
 				+ $"  PlayerData={FormatResource(PlayerData)}\n"
 				+ $"  CurrentContract={FormatResource(CurrentContract)}\n"
 				+ $"  InventoryData={FormatResource(InventoryData)}\n"
+				+ $"  OutpostBuildings={OutpostBuildings?.Count ?? 0}\n"
 				+ $"  ContractsCompleted={ContractsCompleted}\n"
 				+ $"  Gold={Gold}";
 		}

--- a/autoload/save/data/RunData.cs
+++ b/autoload/save/data/RunData.cs
@@ -7,7 +7,7 @@ namespace SaveData {
 	public partial class RunData : SaveResource {
 		[Export] public Biomes CurrentBiome { get; set; } = Biomes.GrasslandsA;
 		[Export] public Locations CurrentLocation { get; set; } = Locations.Village;
-		[Export] public PlayerData PlayerData { get; set; } = new PlayerData();
+		[Export] public PlayerData PlayerData { get; set; }
 		[Export] public Contract CurrentContract { get; set; } = null;
 		[Export] public Array<BuildingData> OutpostBuildings { get; set; }
 		[Export] public int ContractsCompleted { get; set; } = 0;

--- a/autoload/save/data/RunData.cs
+++ b/autoload/save/data/RunData.cs
@@ -9,7 +9,6 @@ namespace SaveData {
 		[Export] public Locations CurrentLocation { get; set; } = Locations.Village;
 		[Export] public PlayerData PlayerData { get; set; } = new PlayerData();
 		[Export] public Contract CurrentContract { get; set; } = null;
-		[Export] public InventoryData InventoryData { get; set; } = new InventoryData();
 		[Export] public Array<BuildingData> OutpostBuildings { get; set; }
 		[Export] public int ContractsCompleted { get; set; } = 0;
 		[Export] public int Gold { get; set; } = 100;
@@ -19,7 +18,6 @@ namespace SaveData {
 				+ $"  CurrentLocation={CurrentLocation}\n"
 				+ $"  PlayerData={FormatResource(PlayerData)}\n"
 				+ $"  CurrentContract={FormatResource(CurrentContract)}\n"
-				+ $"  InventoryData={FormatResource(InventoryData)}\n"
 				+ $"  OutpostBuildings={OutpostBuildings?.Count ?? 0}\n"
 				+ $"  ContractsCompleted={ContractsCompleted}\n"
 				+ $"  Gold={Gold}";

--- a/autoload/save/data/RunData.cs
+++ b/autoload/save/data/RunData.cs
@@ -9,7 +9,7 @@ namespace SaveData {
 		[Export] public Locations CurrentLocation { get; set; } = Locations.Village;
 		[Export] public PlayerData PlayerData { get; set; }
 		[Export] public Contract CurrentContract { get; set; } = null;
-		[Export] public Array<BuildingData> OutpostBuildings { get; set; }
+		[Export] public OutpostData OutpostData { get; set; }
 		[Export] public int ContractsCompleted { get; set; } = 0;
 		[Export] public int Gold { get; set; } = 100;
 		public override string ToString() {
@@ -18,7 +18,7 @@ namespace SaveData {
 				+ $"  CurrentLocation={CurrentLocation}\n"
 				+ $"  PlayerData={FormatResource(PlayerData)}\n"
 				+ $"  CurrentContract={FormatResource(CurrentContract)}\n"
-				+ $"  OutpostBuildings={OutpostBuildings?.Count ?? 0}\n"
+				+ $"  OutpostData={FormatResource(OutpostData)}\n"
 				+ $"  ContractsCompleted={ContractsCompleted}\n"
 				+ $"  Gold={Gold}";
 		}

--- a/autoload/save/data/SettingsData.cs
+++ b/autoload/save/data/SettingsData.cs
@@ -16,8 +16,12 @@ namespace SaveData {
 		[Export]
 		public bool MusicEnabled { get; set; } = true;
 
+		[ExportGroup("Gameplay")]
+		[Export]
+		public bool EnableFirstRunTips { get; set; } = true;
+
 		public override string ToString() {
-			return $"SettingsData: DataVersion={DataVersion}, SfxVolumePercent={SfxVolumePercent}, SfxEnabled={SfxEnabled}, MusicVolumePercent={MusicVolumePercent}, MusicEnabled={MusicEnabled}";
+			return $"SettingsData: DataVersion={DataVersion}, SfxVolumePercent={SfxVolumePercent}, SfxEnabled={SfxEnabled}, MusicVolumePercent={MusicVolumePercent}, MusicEnabled={MusicEnabled}, EnableFirstRunTips={EnableFirstRunTips}";
 		}
 	}
 }

--- a/autoload/save/data/SettingsData.cs
+++ b/autoload/save/data/SettingsData.cs
@@ -3,8 +3,21 @@ using Godot;
 namespace SaveData {
 	[GlobalClass]
 	public partial class SettingsData : SaveResource {
+		[ExportGroup("Sound")]
+		[Export(PropertyHint.Range, "0,100,1")]
+		public float SfxVolumePercent { get; set; } = 72.0f;
+
+		[Export]
+		public bool SfxEnabled { get; set; } = true;
+
+		[Export(PropertyHint.Range, "0,100,1")]
+		public float MusicVolumePercent { get; set; } = 84.0f;
+
+		[Export]
+		public bool MusicEnabled { get; set; } = true;
+
 		public override string ToString() {
-			return $"SettingsData: DataVersion={DataVersion}";
+			return $"SettingsData: DataVersion={DataVersion}, SfxVolumePercent={SfxVolumePercent}, SfxEnabled={SfxEnabled}, MusicVolumePercent={MusicVolumePercent}, MusicEnabled={MusicEnabled}";
 		}
 	}
 }

--- a/core/buildings/data/blacksmith.tres
+++ b/core/buildings/data/blacksmith.tres
@@ -1,8 +1,9 @@
-[gd_resource type="Resource" script_class="BuildingData" load_steps=8 format=3]
+[gd_resource type="Resource" script_class="BuildingData" load_steps=9 format=3]
 
 [ext_resource type="Script" uid="uid://cd5blmxgvl3oe" path="res://scenes/components/outpost/BuildingData.cs" id="1_building"]
 [ext_resource type="Script" uid="uid://enkabhmf46kb" path="res://scenes/overlays/building/BuildingOverlayButtonData.cs" id="2_button"]
 [ext_resource type="PackedScene" path="res://scenes/overlays/storefront/StorefrontOverlay.tscn" id="3_storefront"]
+[ext_resource type="PackedScene" path="res://scenes/overlays/building/SmithOverlay.tscn" id="4_smith"]
 [ext_resource type="Resource" path="res://core/items/data/iron_sword.tres" id="4_iron_sword"]
 [ext_resource type="Resource" path="res://core/items/data/health_potion.tres" id="5_health_potion"]
 [ext_resource type="Resource" path="res://core/items/data/leather_armor.tres" id="6_leather_armor"]
@@ -13,6 +14,7 @@ size = Vector2(64, 64)
 [sub_resource type="Resource" id="Resource_forge_button"]
 script = ExtResource("2_button")
 LabelName = "Forge"
+PathController = ExtResource("4_smith")
 
 [sub_resource type="Resource" id="Resource_shop_button"]
 script = ExtResource("2_button")

--- a/core/buildings/data/blacksmith.tres
+++ b/core/buildings/data/blacksmith.tres
@@ -7,6 +7,13 @@
 [ext_resource type="Resource" path="res://core/items/data/health_potion.tres" id="5_health_potion"]
 [ext_resource type="Resource" path="res://core/items/data/leather_armor.tres" id="6_leather_armor"]
 
+[sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_building"]
+size = Vector2(64, 64)
+
+[sub_resource type="Resource" id="Resource_forge_button"]
+script = ExtResource("2_button")
+LabelName = "Forge"
+
 [sub_resource type="Resource" id="Resource_shop_button"]
 script = ExtResource("2_button")
 LabelName = "Shop"
@@ -14,8 +21,10 @@ PathController = ExtResource("3_storefront")
 
 [resource]
 script = ExtResource("1_building")
-LabelName = "Storefront"
-Description = "Buy useful supplies before leaving the outpost."
-OwnerText = "Coin on the counter, goods in the bag. Take a look before the roads take their share."
-OverlayButtons = Array[Resource]([SubResource("Resource_shop_button")])
+LabelName = "Blacksmith"
+Description = "Forge, repair, and improve equipment."
+OwnerText = "Steel remembers every strike. Bring me coin and materials, and I'll make your gear remember victory."
+OwnerTexture = SubResource("PlaceholderTexture2D_building")
+BuildingTexture = SubResource("PlaceholderTexture2D_building")
+OverlayButtons = Array[Resource]([SubResource("Resource_forge_button"), SubResource("Resource_shop_button")])
 StorefrontItems = Array[Resource]([ExtResource("4_iron_sword"), ExtResource("5_health_potion"), ExtResource("6_leather_armor")])

--- a/core/buildings/data/general_goods.tres
+++ b/core/buildings/data/general_goods.tres
@@ -1,0 +1,26 @@
+[gd_resource type="Resource" script_class="BuildingData" load_steps=8 format=3]
+
+[ext_resource type="Script" uid="uid://cd5blmxgvl3oe" path="res://scenes/components/outpost/BuildingData.cs" id="1_building"]
+[ext_resource type="Script" uid="uid://enkabhmf46kb" path="res://scenes/overlays/building/BuildingOverlayButtonData.cs" id="2_button"]
+[ext_resource type="PackedScene" path="res://scenes/overlays/storefront/StorefrontOverlay.tscn" id="3_storefront"]
+[ext_resource type="Resource" path="res://core/items/data/health_potion.tres" id="4_health_potion"]
+[ext_resource type="Resource" path="res://core/items/data/arrow_bundle.tres" id="5_arrow_bundle"]
+[ext_resource type="Resource" path="res://core/items/data/hunter_bow.tres" id="6_hunter_bow"]
+
+[sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_building"]
+size = Vector2(64, 64)
+
+[sub_resource type="Resource" id="Resource_shop_button"]
+script = ExtResource("2_button")
+LabelName = "Shop"
+PathController = ExtResource("3_storefront")
+
+[resource]
+script = ExtResource("1_building")
+LabelName = "General Goods"
+Description = "Basic travel supplies for contracts and recovery."
+OwnerText = "Nothing fancy, nothing cursed, and mostly nothing that bites. Tell me what you're missing."
+OwnerTexture = SubResource("PlaceholderTexture2D_building")
+BuildingTexture = SubResource("PlaceholderTexture2D_building")
+OverlayButtons = Array[Resource]([SubResource("Resource_shop_button")])
+StorefrontItems = Array[Resource]([ExtResource("4_health_potion"), ExtResource("5_arrow_bundle"), ExtResource("6_hunter_bow")])

--- a/core/buildings/data/jeweler.tres
+++ b/core/buildings/data/jeweler.tres
@@ -1,0 +1,24 @@
+[gd_resource type="Resource" script_class="BuildingData" load_steps=6 format=3]
+
+[ext_resource type="Script" uid="uid://cd5blmxgvl3oe" path="res://scenes/components/outpost/BuildingData.cs" id="1_building"]
+[ext_resource type="Script" uid="uid://enkabhmf46kb" path="res://scenes/overlays/building/BuildingOverlayButtonData.cs" id="2_button"]
+[ext_resource type="PackedScene" path="res://scenes/overlays/storefront/StorefrontOverlay.tscn" id="3_storefront"]
+[ext_resource type="Resource" path="res://core/items/data/wolf_amulet.tres" id="4_wolf_amulet"]
+
+[sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_building"]
+size = Vector2(64, 64)
+
+[sub_resource type="Resource" id="Resource_shop_button"]
+script = ExtResource("2_button")
+LabelName = "Shop"
+PathController = ExtResource("3_storefront")
+
+[resource]
+script = ExtResource("1_building")
+LabelName = "Jeweler"
+Description = "Trade in amulets, charms, and polished valuables."
+OwnerText = "Every stone has a temperament. Spend carefully, and it might choose to favor you."
+OwnerTexture = SubResource("PlaceholderTexture2D_building")
+BuildingTexture = SubResource("PlaceholderTexture2D_building")
+OverlayButtons = Array[Resource]([SubResource("Resource_shop_button")])
+StorefrontItems = Array[Resource]([ExtResource("4_wolf_amulet")])

--- a/core/items/ItemBase.cs
+++ b/core/items/ItemBase.cs
@@ -12,6 +12,7 @@ public partial class ItemBase : Resource {
 	[Export] public int MaxStackSize { get; set; } = 1;
 	[Export] public int Cost { get; set; } = 0;
 	[Export] public string ItemID { get; set; }
+	[Export] public ItemOutpostCompatibilityData OutpostCompatibility { get; set; }
 	[Export] public bool IsConsumable { get; set; } = false;
 	[Export] public int UseCountMax { get; set; } = 0;
 	[Export] public int UseCountDefault { get; set; } = 0;
@@ -91,5 +92,13 @@ public partial class ItemBase : Resource {
 
 	public override string ToString() {
 		return $"{GetType().Name}(Name={ItemName}, Cost={Cost}, MaxStack={MaxStackSize}, Uses={UseCountCurrent}/{UseCountMax}, Condition={ConditionCurrent}/{ConditionMax})";
+	}
+
+	public bool HasCompatibility(OutpostBuildingCompatibility compatibility) {
+		return OutpostCompatibility != null && OutpostCompatibility.HasCompatibility(compatibility);
+	}
+
+	public bool IsCompatibleWith(OutpostBuildingCompatibility compatibility) {
+		return OutpostCompatibility == null || OutpostCompatibility.IsCompatibleWith(compatibility);
 	}
 }

--- a/core/items/ItemOutpostCompatibilityData.cs
+++ b/core/items/ItemOutpostCompatibilityData.cs
@@ -1,0 +1,18 @@
+#nullable enable
+
+using Godot;
+using Godot.Collections;
+using MyTypes;
+
+[GlobalClass]
+public partial class ItemOutpostCompatibilityData : Resource {
+	[Export] public Array<OutpostBuildingCompatibility> CompatibleBuildings { get; set; } = new();
+
+	public bool HasCompatibility(OutpostBuildingCompatibility compatibility) {
+		return CompatibleBuildings != null && CompatibleBuildings.Contains(compatibility);
+	}
+
+	public bool IsCompatibleWith(OutpostBuildingCompatibility compatibility) {
+		return CompatibleBuildings == null || CompatibleBuildings.Count == 0 || CompatibleBuildings.Contains(compatibility);
+	}
+}

--- a/core/items/ItemOutpostCompatibilityData.cs.uid
+++ b/core/items/ItemOutpostCompatibilityData.cs.uid
@@ -1,0 +1,1 @@
+uid://v14px24v4ful

--- a/core/items/data/arrow_bundle.tres
+++ b/core/items/data/arrow_bundle.tres
@@ -1,6 +1,11 @@
-[gd_resource type="Resource" script_class="ItemAmmo" load_steps=2 format=3]
+[gd_resource type="Resource" script_class="ItemAmmo" load_steps=3 format=3]
 
 [ext_resource type="Script" path="res://core/items/ItemAmmo.cs" id="1_item"]
+[ext_resource type="Script" path="res://core/items/ItemOutpostCompatibilityData.cs" id="2_compatibility"]
+
+[sub_resource type="Resource" id="Resource_compatibility"]
+script = ExtResource("2_compatibility")
+CompatibleBuildings = Array[int]([])
 
 [resource]
 script = ExtResource("1_item")
@@ -8,6 +13,7 @@ ItemName = "Arrow Bundle"
 MaxStackSize = 99
 Cost = 5
 ItemID = "item_arrow_bundle"
+OutpostCompatibility = SubResource("Resource_compatibility")
 IsConsumable = true
 UseCountMax = 99
 UseCountDefault = 20

--- a/core/items/data/health_potion.tres
+++ b/core/items/data/health_potion.tres
@@ -1,6 +1,11 @@
-[gd_resource type="Resource" script_class="ItemConsumable" load_steps=2 format=3]
+[gd_resource type="Resource" script_class="ItemConsumable" load_steps=3 format=3]
 
 [ext_resource type="Script" path="res://core/items/ItemConsumable.cs" id="1_item"]
+[ext_resource type="Script" path="res://core/items/ItemOutpostCompatibilityData.cs" id="2_compatibility"]
+
+[sub_resource type="Resource" id="Resource_compatibility"]
+script = ExtResource("2_compatibility")
+CompatibleBuildings = Array[int]([])
 
 [resource]
 script = ExtResource("1_item")
@@ -8,6 +13,7 @@ ItemName = "Health Potion"
 MaxStackSize = 10
 Cost = 8
 ItemID = "item_health_potion"
+OutpostCompatibility = SubResource("Resource_compatibility")
 IsConsumable = true
 UseCountMax = 10
 UseCountDefault = 1

--- a/core/items/data/hunter_bow.tres
+++ b/core/items/data/hunter_bow.tres
@@ -1,6 +1,11 @@
-[gd_resource type="Resource" script_class="ItemEquipable" load_steps=2 format=3]
+[gd_resource type="Resource" script_class="ItemEquipable" load_steps=3 format=3]
 
 [ext_resource type="Script" path="res://core/items/ItemEquipable.cs" id="1_item"]
+[ext_resource type="Script" path="res://core/items/ItemOutpostCompatibilityData.cs" id="2_compatibility"]
+
+[sub_resource type="Resource" id="Resource_compatibility"]
+script = ExtResource("2_compatibility")
+CompatibleBuildings = Array[int]([])
 
 [resource]
 script = ExtResource("1_item")
@@ -8,6 +13,7 @@ ItemName = "Hunter Bow"
 MaxStackSize = 1
 Cost = 35
 ItemID = "item_hunter_bow"
+OutpostCompatibility = SubResource("Resource_compatibility")
 HasCondition = true
 ConditionMax = 100
 ConditionDefault = 100

--- a/core/items/data/iron_sword.tres
+++ b/core/items/data/iron_sword.tres
@@ -1,6 +1,11 @@
-[gd_resource type="Resource" script_class="ItemEquipable" load_steps=2 format=3]
+[gd_resource type="Resource" script_class="ItemEquipable" load_steps=3 format=3]
 
 [ext_resource type="Script" path="res://core/items/ItemEquipable.cs" id="1_item"]
+[ext_resource type="Script" path="res://core/items/ItemOutpostCompatibilityData.cs" id="2_compatibility"]
+
+[sub_resource type="Resource" id="Resource_compatibility"]
+script = ExtResource("2_compatibility")
+CompatibleBuildings = Array[int]([2])
 
 [resource]
 script = ExtResource("1_item")
@@ -8,6 +13,7 @@ ItemName = "Iron Sword"
 MaxStackSize = 1
 Cost = 25
 ItemID = "item_iron_sword"
+OutpostCompatibility = SubResource("Resource_compatibility")
 HasCondition = true
 ConditionMax = 100
 ConditionDefault = 100

--- a/core/items/data/leather_armor.tres
+++ b/core/items/data/leather_armor.tres
@@ -1,6 +1,11 @@
-[gd_resource type="Resource" script_class="ItemArmor" load_steps=2 format=3]
+[gd_resource type="Resource" script_class="ItemArmor" load_steps=3 format=3]
 
 [ext_resource type="Script" path="res://core/items/ItemArmor.cs" id="1_item"]
+[ext_resource type="Script" path="res://core/items/ItemOutpostCompatibilityData.cs" id="2_compatibility"]
+
+[sub_resource type="Resource" id="Resource_compatibility"]
+script = ExtResource("2_compatibility")
+CompatibleBuildings = Array[int]([])
 
 [resource]
 script = ExtResource("1_item")
@@ -8,6 +13,7 @@ ItemName = "Leather Armor"
 MaxStackSize = 1
 Cost = 30
 ItemID = "item_leather_armor"
+OutpostCompatibility = SubResource("Resource_compatibility")
 HasCondition = true
 ConditionMax = 100
 ConditionDefault = 100

--- a/core/items/data/wolf_amulet.tres
+++ b/core/items/data/wolf_amulet.tres
@@ -1,6 +1,11 @@
-[gd_resource type="Resource" script_class="ItemAmulet" load_steps=2 format=3]
+[gd_resource type="Resource" script_class="ItemAmulet" load_steps=3 format=3]
 
 [ext_resource type="Script" path="res://core/items/ItemAmulet.cs" id="1_item"]
+[ext_resource type="Script" path="res://core/items/ItemOutpostCompatibilityData.cs" id="2_compatibility"]
+
+[sub_resource type="Resource" id="Resource_compatibility"]
+script = ExtResource("2_compatibility")
+CompatibleBuildings = Array[int]([])
 
 [resource]
 script = ExtResource("1_item")
@@ -8,3 +13,4 @@ ItemName = "Wolf Amulet"
 MaxStackSize = 1
 Cost = 50
 ItemID = "item_wolf_amulet"
+OutpostCompatibility = SubResource("Resource_compatibility")

--- a/core/types/Types.cs
+++ b/core/types/Types.cs
@@ -33,6 +33,17 @@ namespace MyTypes {
 		Enchanter,
 	}
 
+	public enum OutpostBuildingCompatibility {
+		None = 0,
+		General = 1,
+		Smith = 2,
+		Jewelry = 3,
+		Alchemy = 4,
+		Fletching = 5,
+		Arcana = 6,
+		Enchanting = 7,
+	}
+
 	public enum AmmoType {
 		None,
 		Arrow

--- a/core/ui/ControlGotoScene.cs
+++ b/core/ui/ControlGotoScene.cs
@@ -38,7 +38,7 @@ public partial class ControlGotoScene : Control {
 
 	private PackedScene GetSceneToLoad() {
 		var saveNode = SaveNode.Get();
-		if (!saveNode.HadPlayerDataOnLoad)
+		if (saveNode.PlayerData == null)
 			return ResourceLoader.Load<PackedScene>(NewCharacterScenePath);
 
 		return SceneToLoad;

--- a/docs/AI-Summary/Outpost-System.md
+++ b/docs/AI-Summary/Outpost-System.md
@@ -1,0 +1,117 @@
+# Outpost System Memory
+
+Internal AI memory for the outpost and building system. Keep this aligned with current code and intended direction.
+
+## Core Intent
+
+The outpost is the between-run hub. Some buildings are permanent, while other building slots are generated and saved as part of the current run.
+
+Important design split:
+
+- `Node2D` is used for world placement, collision, and game-object logic.
+- `Control` is used for UI such as building prompts, overlay buttons, owner portraits, and dialogue text.
+- Do not build non-trivial UI from `Node2D` unless it is intentionally very simple world art.
+
+## Important Scenes And Scripts
+
+- `scenes/main/outpost/Outpost.tscn`: main outpost scene.
+- `scenes/main/outpost/OutpostBuildings.cs`: script on `World/OutpostBuildings`; owns random/generated outpost building generation.
+- `scenes/components/outpost/buildingTemplate.tscn`: reusable in-world building scene.
+- `scenes/components/outpost/BuildingTemplate.cs`: click/touch handler for a building; always opens `BuildingOverlay.tscn`.
+- `scenes/components/outpost/BuildingData.cs`: resource that owns building display data and overlay generation logic.
+- `scenes/overlays/building/BuildingOverlay.tscn`: full-screen building overlay.
+- `scenes/overlays/building/BuildingOverlay.cs`: intentionally thin; forwards `Update(BuildingData)` to the resource.
+- `scenes/overlays/building/BuildingOverlayButtonData.cs`: resource for one building overlay button.
+
+## Save Flow
+
+Generated outpost buildings are saved inside `RunData`:
+
+```csharp
+[Export] public Array<BuildingData> OutpostBuildings { get; set; }
+```
+
+Current first-entry behavior:
+
+- `RunData.OutpostBuildings == null` means the player has not had this outpost generated yet.
+- `OutpostBuildings._Ready()` checks this value through `SaveNode.Get().RunData.OutpostBuildings`.
+- If null, it generates mock data for now, assigns it to `RunData.OutpostBuildings`, and calls `SaveNode.SaveRunData()`.
+- On later visits, saved `BuildingData` is reused.
+
+Be careful changing exported names on `BuildingData` because saved `.tres` run data can serialize these fields.
+
+## Current Outpost Layout
+
+In `Outpost.tscn`:
+
+- `World/OutpostBuildings` owns randomized/generated slots.
+- Generated slots are named `RandomSlot1`, `RandomSlot2`, `RandomSlot3`.
+- Permanent outpost buildings currently include `Contract` and `Inn` as direct children under `World`.
+- `Contract` and `Inn` intentionally instance `buildingTemplate.tscn` because they should always exist in an outpost.
+- Random slots are empty `Node2D` placeholders; `OutpostBuildings.cs` instantiates `buildingTemplate.tscn` into them.
+
+## BuildingData Resource
+
+`BuildingData` is the central data/resource object for a building. It should contain the information needed to generate the building overlay and should be suitable for saving in `RunData`.
+
+Current exported data includes:
+
+- `LabelName`: building title, such as `Inn`, `Contract`, or `Blacksmith`.
+- `Description`: short descriptive text for `PanelBuilding`.
+- `OwnerTexture`: portrait/storekeeper/building-owner image for the overlay homepage.
+- `OwnerText`: rich text dialogue shown in the center homepage area.
+- `OwnerTextRevealSeconds`: duration for RPG-style dialogue reveal.
+- `BuildingTexture`: in-world building sprite texture.
+- `OverlayButtons`: array of `BuildingOverlayButtonData` resources.
+
+`BuildingData.Generate(BuildingOverlay overlay)` owns the overlay regeneration. Keep the overlay construction logic here unless there is a strong reason to move it.
+
+## Building Overlay
+
+`BuildingOverlay` should stay simple. Its public flow is:
+
+```csharp
+public void Update(BuildingData buildingData) {
+    buildingData.Generate(this);
+}
+```
+
+The overlay homepage currently has:
+
+- Owner/building image on the left.
+- Rich text dialogue in the center.
+- Dialogue reveal animation using `RichTextLabel.VisibleRatio` from `0` to `1`.
+- Bottom action buttons generated from `BuildingData.OverlayButtons`.
+
+`BuildingOverlayButtonData` currently has:
+
+- `IconPath`: path to an icon resource; empty path falls back to placeholder icon.
+- `LabelName`: button text.
+- `PathController`: packed scene opened when the button is pressed.
+
+## Current Mock Data
+
+`OutpostBuildings.GenerateMockBuildings()` currently creates one mock `Blacksmith` building.
+
+Current placeholder behavior:
+
+- Blacksmith uses generated `PlaceholderTexture2D` for building and owner images.
+- The mock `Forge` button uses an empty icon path so `BuildingData` falls back to a placeholder icon.
+- The mock `Forge` button currently has no `PathController`; pressing it logs a warning.
+
+## Permanent Building Data Files
+
+Permanent building data currently lives in resource files:
+
+- `scenes/components/outpost/inn_building_data.tres`
+- `scenes/components/outpost/contract_building_data.tres`
+
+These are referenced by `Outpost.tscn` on the permanent building template instances.
+
+## Implementation Cautions
+
+- Keep generated building slots separate from permanent buildings.
+- If a building is always present, it can directly instance `buildingTemplate.tscn` in `Outpost.tscn`.
+- If a building is generated/randomized, place only an empty `Node2D` slot in `World/OutpostBuildings` and let `OutpostBuildings.cs` instantiate it.
+- For building UI, prefer data-driven changes in `BuildingData.Generate(...)` over adding more logic to `BuildingOverlay.cs`.
+- Validate C# changes with `dotnet build`, but still run the Godot scene for node path/editor assignment issues.

--- a/docs/AI-Summary/SUMMARY.md
+++ b/docs/AI-Summary/SUMMARY.md
@@ -38,6 +38,7 @@ This folder is for AI assistants to keep project-specific context across coding 
 
 - `docs/AI-Summary/Item-System-Goal.md`: item-system intent, generic dependencies, consumables, condition/durability, ammo, and future extensibility.
 - `docs/AI-Summary/Outpost-System.md`: outpost building generation, `BuildingData`, permanent/random slots, saved run data, and building overlay flow.
+- `docs/AI-Summary/Visual-Character-Plan.md`: procedural player visual structure plan, part-based animation direction, and shared item/equipment art usage.
 
 ## Godot Setup
 

--- a/docs/AI-Summary/SUMMARY.md
+++ b/docs/AI-Summary/SUMMARY.md
@@ -37,6 +37,7 @@ This folder is for AI assistants to keep project-specific context across coding 
 ## AI Detail File Index
 
 - `docs/AI-Summary/Item-System-Goal.md`: item-system intent, generic dependencies, consumables, condition/durability, ammo, and future extensibility.
+- `docs/AI-Summary/Outpost-System.md`: outpost building generation, `BuildingData`, permanent/random slots, saved run data, and building overlay flow.
 
 ## Godot Setup
 
@@ -96,6 +97,7 @@ This folder is for AI assistants to keep project-specific context across coding 
 ## Core Data Models
 
 - `RunData` tracks current biome, current location, current contract, inventory, completed contracts, gold, and active player data.
+- `RunData.OutpostBuildings` stores generated outpost `BuildingData` resources for the current run; `null` means the outpost has not generated its random buildings yet.
 - `PlayerData` tracks player name, equipped items, and skill data.
 - `MetaData`, `SettingsData`, `InventoryData`, `EquipedItemsData`, `PlayerSkillData`, and store data live under `autoload/save/data/`.
 - Shared enums live in `core/types/Types.cs` under `MyTypes` and `SaveData` namespaces.
@@ -135,7 +137,10 @@ This folder is for AI assistants to keep project-specific context across coding 
 - Main flows currently include start menu, run overview, new character selection, and outpost.
 - `RunOverview` wires continue/new-run/back buttons to outpost, new character select, and start menu scenes.
 - `Outpost.tscn` main overlay buttons are split between `TopUI` and `BottomUI`: `ExitButton` changes back to `StartMenu`, `BtnSettings` opens `SettingsOverlay`, `BtnInventory` opens `InventoryOverlay`, `BtnCharacter` opens `CharacterOverlay`, and `BtnCodex` opens `CodexOverlay`.
-- `BuildingTemplate` opens an exported overlay scene when clicked/touched through its `Area2D`, with a 250ms debounce.
+- `Outpost.tscn` has permanent `Contract` and `Inn` building template instances under `World`, plus generated slots under `World/OutpostBuildings` named `RandomSlot1`, `RandomSlot2`, and `RandomSlot3`.
+- `OutpostBuildings.cs` checks `SaveNode.RunData.OutpostBuildings`, generates mock building data when null, saves it to run data, and instantiates `buildingTemplate.tscn` into random slots.
+- `BuildingTemplate` always opens `BuildingOverlay.tscn` when clicked/touched through its `Area2D`, with a 250ms debounce, and passes its `BuildingData` into the overlay.
+- `BuildingOverlay` should stay thin; `BuildingData.Generate(BuildingOverlay)` owns regenerating title, description, owner portrait, RPG-style rich text dialogue, and bottom action buttons.
 - Panel components display stats, gold, run metadata, location, building information, and player top UI.
 - Design UI for landscape phones first. Prefer big readable labels, generous spacing, and large touch targets over compact PC-style layouts.
 - Many UI scenes rely on exact node paths. When editing `.tscn` structure, update corresponding C# paths.

--- a/docs/AI-Summary/Visual-Character-Plan.md
+++ b/docs/AI-Summary/Visual-Character-Plan.md
@@ -1,0 +1,73 @@
+# Visual Character Plan
+
+Internal AI memory for the planned ingame character visual structure.
+
+## Direction
+
+Use a loose procedural `Node2D` puppet instead of starting with `Skeleton2D`.
+
+This means the player scene should keep gameplay and visuals separate:
+
+- `CharacterBody2D` for movement/collision/game logic
+- a child visual root for body-part transforms and equipment visuals
+
+## Recommended Scene Structure
+
+Suggested visual hierarchy:
+
+- `VisualRoot: Node2D`
+- `Body: Node2D`
+- `Head: Node2D`
+- `LeftArmPivot: Node2D`
+- `RightArmPivot: Node2D`
+- `LeftLegPivot: Node2D`
+- `RightLegPivot: Node2D`
+
+Each pivot/body part can then own a `Sprite2D` child.
+
+Equipment and armor visuals should attach to the relevant body-part nodes instead of being baked into one static player sprite.
+
+## Animation Approach
+
+Preferred first implementation is math-driven procedural animation:
+
+- body bob from `sin(time * speed)`
+- arm and leg swing from movement intensity
+- head lag / follow using smoothing
+- body tilt from movement direction
+- `lerp` and `lerp_angle` for smooth transitions
+
+This is preferred over authored frame animation for the current project direction because it is lighter to maintain and fits the desired dynamic/loose feel.
+
+## Equipment Visuals
+
+The project currently separates item icon and equipped/world texture through item resources.
+
+Longer term direction should be a small presentation/visual layer for equipment so the same source art can drive:
+
+- inventory icon
+- equipped/world-held item visual
+- armor body-part overlays
+
+Armor should be split by wearable visual parts where needed instead of assuming one icon texture can represent all ingame body parts.
+
+## SVG Direction
+
+SVG should be treated as the source art format.
+
+Preferred usage:
+
+- keep one SVG source for an item or equipment design
+- reuse that source for inventory and ingame presentation assets
+- use imported `Texture2D` outputs in Godot scenes/resources rather than depending on runtime SVG manipulation for gameplay visuals
+
+This allows the same visual language across UI and ingame rendering while still supporting separate body-part overlays for armor and held-item visuals.
+
+## Implementation Preference
+
+When this gets built, prefer:
+
+1. `Node2D` puppet hierarchy first
+2. procedural math-based animation first
+3. equipment visual resource/data second
+4. more advanced systems like bones/IK only if the simpler setup becomes limiting

--- a/docs/usertests/P1-1.md
+++ b/docs/usertests/P1-1.md
@@ -1,0 +1,16 @@
+# usertest 1 - P1
+
+- IsFirstRun() => MetaData EnableFirstRunTips = true;
+  - Infotext ono character select
+  - Infotext about stats
+  - Include in settings a bool to disable, enable this IsFirstRun tips
+
+- Characterselect
+  - FirstRun = Popup box, read IsFirstRun()
+  - Make skills clickable, have the component have a "SkillDescriptionIsClickable : boolean"; make it green
+
+- Outpost
+  - Make "Equip" button green
+  - Your level is EarnedLevel - StartLevel so you start at level 1 not 9, do CurrentXpTotal - StartXpTotal
+  - Show gold on top when in buildings
+  - Show itemcount in store before clicking on it, if item has a count more than 1

--- a/scenes/components/character/NewCharacterComponent.cs
+++ b/scenes/components/character/NewCharacterComponent.cs
@@ -44,8 +44,10 @@ public partial class NewCharacterComponent : Control {
 
 	private void OnSelectPressed() {
 		var saveNode = SaveNode.Get();
-		saveNode.RunData.PlayerData = PlayerData;
+		saveNode.WipeRun();
+		saveNode.RunData.PlayerData = PlayerData.Duplicate(true) as PlayerData ?? new PlayerData();
 		saveNode.RunData.InventoryData = new InventoryData();
+
 		if (PlayerData.StartingItem != null)
 			saveNode.RunData.InventoryData.AddItem(PlayerData.StartingItem.Duplicate(true) as ItemBase);
 

--- a/scenes/components/character/NewCharacterComponent.cs
+++ b/scenes/components/character/NewCharacterComponent.cs
@@ -46,12 +46,11 @@ public partial class NewCharacterComponent : Control {
 		var saveNode = SaveNode.Get();
 		saveNode.WipeRun();
 		saveNode.RunData.PlayerData = PlayerData.Duplicate(true) as PlayerData ?? new PlayerData();
-		saveNode.RunData.InventoryData = new InventoryData();
+		saveNode.RunData.PlayerData.InventoryData = new InventoryData();
 
 		if (PlayerData.StartingItem != null)
-			saveNode.RunData.InventoryData.AddItem(PlayerData.StartingItem.Duplicate(true) as ItemBase);
+			saveNode.RunData.PlayerData.InventoryData.AddItem(PlayerData.StartingItem.Duplicate(true) as ItemBase);
 
-		saveNode.SaveRunData();
 		saveNode.RefreshStartCharacters();
 
 		CallDeferred(MethodName.GoToOutpost);

--- a/scenes/components/character/NewCharacterComponent.tscn
+++ b/scenes/components/character/NewCharacterComponent.tscn
@@ -26,8 +26,10 @@ offset_top = 0.2559967
 offset_right = -58.0
 offset_bottom = -0.25601196
 UseSaveNodeData = false
+SkillDescriptionIsClickable = true
 
 [node name="Button" type="Button" parent="." unique_id=773450435]
+modulate = Color(0.2, 0.75, 0.2, 1)
 layout_mode = 1
 anchors_preset = -1
 anchor_top = 0.82600003

--- a/scenes/components/equipment/EquipmentPanel.cs
+++ b/scenes/components/equipment/EquipmentPanel.cs
@@ -5,8 +5,10 @@ public partial class EquipmentPanel : PanelContainer {
 	public delegate void EquipmentSlotPressedEventHandler(int slotIndex, ItemBase item, string slotName);
 
 	private bool _enableButtonPresses = true;
+	private bool _skillDescriptionIsClickable;
 	private bool _useSaveNodeData = true;
 	private EquipedItemsData _equipedItems;
+	private PanelStats _panelStats;
 
 	[Export]
 	public bool EnableButtonPresses {
@@ -14,6 +16,15 @@ public partial class EquipmentPanel : PanelContainer {
 		set {
 			_enableButtonPresses = value;
 			ApplyInteractionState();
+		}
+	}
+
+	[Export]
+	public bool SkillDescriptionIsClickable {
+		get => _skillDescriptionIsClickable;
+		set {
+			_skillDescriptionIsClickable = value;
+			ApplyStatsInteractionState();
 		}
 	}
 
@@ -48,6 +59,7 @@ public partial class EquipmentPanel : PanelContainer {
 	private PlaceholderTexture2D _placeholderIcon = new() { Size = new Vector2I(64, 64) };
 
 	public override void _Ready() {
+		_panelStats = GetNodeOrNull<PanelStats>("MarginContainer/EquipmentLayout/PanelStats");
 		_equipmentButtons = new[] {
 			GetNode<Button>("MarginContainer/EquipmentLayout/EquipmentBody/LeftSlots/Slot1"),
 			GetNode<Button>("MarginContainer/EquipmentLayout/EquipmentBody/LeftSlots/Slot2"),
@@ -63,6 +75,7 @@ public partial class EquipmentPanel : PanelContainer {
 		}
 
 		ApplyInteractionState();
+		ApplyStatsInteractionState();
 		Render();
 	}
 
@@ -89,6 +102,13 @@ public partial class EquipmentPanel : PanelContainer {
 			button.FocusMode = EnableButtonPresses ? FocusModeEnum.All : FocusModeEnum.None;
 			button.MouseFilter = EnableButtonPresses ? MouseFilterEnum.Stop : MouseFilterEnum.Ignore;
 		}
+	}
+
+	private void ApplyStatsInteractionState() {
+		if (_panelStats == null)
+			return;
+
+		_panelStats.SkillDescriptionIsClickable = SkillDescriptionIsClickable;
 	}
 
 	private void OnEquipmentSlotPressed(int slotIndex) {

--- a/scenes/components/outpost/BuildingData.cs
+++ b/scenes/components/outpost/BuildingData.cs
@@ -88,4 +88,38 @@ public partial class BuildingData : Resource {
 
 		GlobalOverlay.Get()?.AddChild(overlay);
 	}
+
+	public override string ToString() {
+		return $"BuildingData(Name={LabelName}, Description={Description}, Buttons={FormatButtons(OverlayButtons)}, StorefrontItems={FormatItems(StorefrontItems)})";
+	}
+
+	private static string FormatButtons(Array<BuildingOverlayButtonData> buttons) {
+		if (buttons == null || buttons.Count == 0)
+			return "[]";
+
+		var result = "[";
+		for (var i = 0; i < buttons.Count; i++) {
+			if (i > 0)
+				result += ", ";
+
+			result += buttons[i]?.LabelName ?? "None";
+		}
+
+		return result + "]";
+	}
+
+	private static string FormatItems(Array<ItemBase> items) {
+		if (items == null || items.Count == 0)
+			return "[]";
+
+		var result = "[";
+		for (var i = 0; i < items.Count; i++) {
+			if (i > 0)
+				result += ", ";
+
+			result += items[i]?.ItemName ?? "None";
+		}
+
+		return result + "]";
+	}
 }

--- a/scenes/components/outpost/BuildingData.cs
+++ b/scenes/components/outpost/BuildingData.cs
@@ -12,6 +12,7 @@ public partial class BuildingData : Resource {
 	[Export] public double OwnerTextRevealSeconds { get; set; } = 1.5;
 	[Export] public Texture2D BuildingTexture { get; set; }
 	[Export] public Array<BuildingOverlayButtonData> OverlayButtons { get; set; } = new();
+	[Export] public Array<ItemBase> StorefrontItems { get; set; } = new();
 
 	public void Generate(BuildingOverlay overlay) {
 		if (overlay == null)
@@ -75,12 +76,16 @@ public partial class BuildingData : Resource {
 		return ResourceLoader.Load<Texture2D>(iconPath) ?? _fallbackIcon;
 	}
 
-	private static void OpenPathController(BuildingOverlayButtonData buttonData) {
+	private void OpenPathController(BuildingOverlayButtonData buttonData) {
 		if (buttonData.PathController == null) {
 			GD.PushWarning($"Building overlay button '{buttonData.LabelName}' has no path controller configured.");
 			return;
 		}
 
-		GlobalOverlay.Get()?.AddOverlay(buttonData.PathController);
+		var overlay = buttonData.PathController.Instantiate();
+		if (overlay is StorefrontOverlay storefrontOverlay)
+			storefrontOverlay.Update(this);
+
+		GlobalOverlay.Get()?.AddChild(overlay);
 	}
 }

--- a/scenes/components/outpost/BuildingData.cs
+++ b/scenes/components/outpost/BuildingData.cs
@@ -1,0 +1,86 @@
+using Godot;
+using Godot.Collections;
+
+[GlobalClass]
+public partial class BuildingData : Resource {
+	private readonly Texture2D _fallbackIcon = new PlaceholderTexture2D { Size = new Vector2I(64, 64) };
+
+	[Export] public string LabelName { get; set; } = "Building";
+	[Export(PropertyHint.MultilineText)] public string Description { get; set; } = "";
+	[Export] public Texture2D OwnerTexture { get; set; }
+	[Export(PropertyHint.MultilineText)] public string OwnerText { get; set; } = "Welcome.";
+	[Export] public double OwnerTextRevealSeconds { get; set; } = 1.5;
+	[Export] public Texture2D BuildingTexture { get; set; }
+	[Export] public Array<BuildingOverlayButtonData> OverlayButtons { get; set; } = new();
+
+	public void Generate(BuildingOverlay overlay) {
+		if (overlay == null)
+			return;
+
+		var titleLabel = overlay.GetNodeOrNull<Label>("PanelBuilding/HBoxContainer/Labels/Label");
+		if (titleLabel != null)
+			titleLabel.Text = string.IsNullOrWhiteSpace(LabelName) ? "Building" : LabelName;
+
+		var descriptionLabel = overlay.GetNodeOrNull<Label>("PanelBuilding/HBoxContainer/Labels/Label2");
+		if (descriptionLabel != null)
+			descriptionLabel.Text = Description;
+
+		var ownerTexture = overlay.GetNodeOrNull<TextureRect>("PanelOverlay/CenterContent/OwnerPortrait");
+		if (ownerTexture != null)
+			ownerTexture.Texture = OwnerTexture ?? _fallbackIcon;
+
+		var ownerText = overlay.GetNodeOrNull<RichTextLabel>("PanelOverlay/CenterContent/DialoguePanel/MarginContainer/OwnerText");
+		if (ownerText != null) {
+			ownerText.Text = OwnerText;
+			ownerText.VisibleRatio = 0.0f;
+
+			var tween = overlay.CreateTween();
+			tween.TweenProperty(ownerText, "visible_ratio", 1.0f, Mathf.Max(0.01, OwnerTextRevealSeconds));
+		}
+
+		var bottomUi = overlay.GetNodeOrNull<HBoxContainer>("BottomUI");
+		if (bottomUi == null)
+			return;
+
+		foreach (var child in bottomUi.GetChildren())
+			child.QueueFree();
+
+		foreach (var buttonData in OverlayButtons) {
+			if (buttonData == null)
+				continue;
+
+			bottomUi.AddChild(CreateButton(buttonData));
+		}
+	}
+
+	private Button CreateButton(BuildingOverlayButtonData buttonData) {
+		var button = new Button {
+			CustomMinimumSize = new Vector2(80, 80),
+			SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
+			Text = buttonData.LabelName,
+			Icon = LoadIcon(buttonData.IconPath),
+			IconAlignment = HorizontalAlignment.Center,
+			VerticalIconAlignment = VerticalAlignment.Top,
+			ExpandIcon = true,
+		};
+
+		button.Pressed += () => OpenPathController(buttonData);
+		return button;
+	}
+
+	private Texture2D LoadIcon(string iconPath) {
+		if (string.IsNullOrWhiteSpace(iconPath))
+			return _fallbackIcon;
+
+		return ResourceLoader.Load<Texture2D>(iconPath) ?? _fallbackIcon;
+	}
+
+	private static void OpenPathController(BuildingOverlayButtonData buttonData) {
+		if (buttonData.PathController == null) {
+			GD.PushWarning($"Building overlay button '{buttonData.LabelName}' has no path controller configured.");
+			return;
+		}
+
+		GlobalOverlay.Get()?.AddOverlay(buttonData.PathController);
+	}
+}

--- a/scenes/components/outpost/BuildingData.cs.uid
+++ b/scenes/components/outpost/BuildingData.cs.uid
@@ -1,0 +1,1 @@
+uid://cd5blmxgvl3oe

--- a/scenes/components/outpost/BuildingTemplate.cs
+++ b/scenes/components/outpost/BuildingTemplate.cs
@@ -2,9 +2,10 @@ using Godot;
 
 public partial class BuildingTemplate : Node2D {
 	private const ulong OpenDebounceMs = 250;
+	private const string BuildingOverlayPath = "res://scenes/overlays/building/BuildingOverlay.tscn";
 
-	[Export] public PackedScene OverlayScene { get; set; }
-	[Export] public Texture2D TextureHouse { get; set; }
+	[Export] public PackedScene BuildingOverlayScene { get; set; } = GD.Load<PackedScene>(BuildingOverlayPath);
+	[Export] public BuildingData BuildingData { get; set; } = new();
 
 	private Sprite2D _houseSprite;
 	private Area2D _area;
@@ -25,8 +26,8 @@ public partial class BuildingTemplate : Node2D {
 	}
 
 	private void ApplyExportedValues() {
-		if (_houseSprite != null && TextureHouse != null)
-			_houseSprite.Texture = TextureHouse;
+		if (_houseSprite != null && BuildingData?.BuildingTexture != null)
+			_houseSprite.Texture = BuildingData.BuildingTexture;
 	}
 
 	private void OnAreaInputEvent(Node viewport, InputEvent @event, long shapeIdx) {
@@ -39,8 +40,8 @@ public partial class BuildingTemplate : Node2D {
 
 		_lastOpenTimeMs = now;
 
-		if (OverlayScene == null) {
-			GD.PushWarning($"{nameof(BuildingTemplate)} on '{Name}' has no overlay scene configured.");
+		if (BuildingOverlayScene == null) {
+			GD.PushWarning($"{nameof(BuildingTemplate)} on '{Name}' could not load BuildingOverlay.");
 			return;
 		}
 
@@ -50,7 +51,11 @@ public partial class BuildingTemplate : Node2D {
 			return;
 		}
 
-		overlay.AddOverlay(OverlayScene);
+		var overlayInstance = BuildingOverlayScene.Instantiate();
+		if (overlayInstance is BuildingOverlay buildingOverlay)
+			buildingOverlay.Update(BuildingData);
+
+		overlay.AddChild(overlayInstance);
 	}
 
 	private static bool IsPressed(InputEvent @event) {

--- a/scenes/components/outpost/BuildingTemplate.cs
+++ b/scenes/components/outpost/BuildingTemplate.cs
@@ -5,13 +5,22 @@ public partial class BuildingTemplate : Node2D {
 
 	[Export] public PackedScene OverlayScene { get; set; }
 	[Export] public Texture2D TextureHouse { get; set; }
+	[Export] public Texture2D TextureIcon { get; set; }
+	[Export] public string DisplayName { get; set; } = "Building";
+	[Export] public Vector2 PromptOffset { get; set; } = new(0, -108);
 
 	private Sprite2D _houseSprite;
+	private Control _prompt;
+	private TextureRect _promptIcon;
+	private Label _promptLabel;
 	private Area2D _area;
 	private ulong _lastOpenTimeMs;
 
 	public override void _Ready() {
 		_houseSprite = GetNodeOrNull<Sprite2D>("SpriteHouse");
+		_prompt = GetNodeOrNull<Control>("ClickPanel");
+		_promptIcon = GetNodeOrNull<TextureRect>("ClickPanel/Icon");
+		_promptLabel = GetNodeOrNull<Label>("ClickPanel/LabelPanel/Label");
 		_area = GetNodeOrNull<Area2D>("Area2D");
 
 		ApplyExportedValues();
@@ -27,6 +36,25 @@ public partial class BuildingTemplate : Node2D {
 	private void ApplyExportedValues() {
 		if (_houseSprite != null && TextureHouse != null)
 			_houseSprite.Texture = TextureHouse;
+
+		if (_promptIcon != null && TextureIcon != null)
+			_promptIcon.Texture = TextureIcon;
+
+		if (_promptLabel != null)
+			_promptLabel.Text = DisplayName;
+
+		UpdatePromptPosition();
+	}
+
+	public override void _Process(double delta) {
+		UpdatePromptPosition();
+	}
+
+	private void UpdatePromptPosition() {
+		if (_prompt == null)
+			return;
+
+		_prompt.GlobalPosition = GlobalPosition + PromptOffset - new Vector2(_prompt.Size.X * 0.5f, 0);
 	}
 
 	private void OnAreaInputEvent(Node viewport, InputEvent @event, long shapeIdx) {

--- a/scenes/components/outpost/buildingTemplate.tscn
+++ b/scenes/components/outpost/buildingTemplate.tscn
@@ -2,11 +2,13 @@
 
 [ext_resource type="Texture2D" uid="uid://dsqb3fvddhg1s" path="res://assets/outpost/buildings/building_placeholder.svg" id="1_8rcmu"]
 [ext_resource type="Script" uid="uid://bt8a8igubvw8b" path="res://scenes/components/outpost/BuildingTemplate.cs" id="2_lm4d7"]
+[ext_resource type="Script" uid="uid://enkabhmf46kb" path="res://scenes/overlays/building/BuildingOverlayButtonData.cs" id="3_0o4qr"]
 [ext_resource type="Script" uid="uid://cd5blmxgvl3oe" path="res://scenes/components/outpost/BuildingData.cs" id="3_building_data"]
+[ext_resource type="Script" uid="uid://cesnllliaw0ql" path="res://core/items/ItemBase.cs" id="4_uxm22"]
+[ext_resource type="Theme" uid="uid://2us73xfo2hnd" path="res://assets/style/DefaultTheme.tres" id="6_i7hfi"]
 
 [sub_resource type="Resource" id="Resource_building_data"]
 script = ExtResource("3_building_data")
-LabelName = "Building"
 Description = "Interact with this building."
 OwnerText = "Welcome. What do you need?"
 BuildingTexture = ExtResource("1_8rcmu")
@@ -15,15 +17,15 @@ BuildingTexture = ExtResource("1_8rcmu")
 size = Vector2(64, 64)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_label_panel"]
+content_margin_left = 8.0
+content_margin_top = 3.0
+content_margin_right = 8.0
+content_margin_bottom = 3.0
 bg_color = Color(0.08, 0.07, 0.06, 0.82)
 corner_radius_top_left = 6
 corner_radius_top_right = 6
 corner_radius_bottom_right = 6
 corner_radius_bottom_left = 6
-content_margin_left = 8.0
-content_margin_top = 3.0
-content_margin_right = 8.0
-content_margin_bottom = 3.0
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_13jms"]
 radius = 61.03278
@@ -43,6 +45,7 @@ offset_top = -108.0
 offset_right = 48.0
 offset_bottom = -28.0
 mouse_filter = 2
+theme = ExtResource("6_i7hfi")
 
 [node name="Icon" type="TextureRect" parent="ClickPanel" unique_id=790543333]
 layout_mode = 1
@@ -70,7 +73,6 @@ theme_override_styles/panel = SubResource("StyleBoxFlat_label_panel")
 
 [node name="Label" type="Label" parent="ClickPanel/LabelPanel" unique_id=429572716]
 layout_mode = 2
-mouse_filter = 2
 text = "Building"
 horizontal_alignment = 1
 vertical_alignment = 1

--- a/scenes/components/outpost/buildingTemplate.tscn
+++ b/scenes/components/outpost/buildingTemplate.tscn
@@ -2,6 +2,14 @@
 
 [ext_resource type="Texture2D" uid="uid://dsqb3fvddhg1s" path="res://assets/outpost/buildings/building_placeholder.svg" id="1_8rcmu"]
 [ext_resource type="Script" uid="uid://bt8a8igubvw8b" path="res://scenes/components/outpost/BuildingTemplate.cs" id="2_lm4d7"]
+[ext_resource type="Script" uid="uid://cd5blmxgvl3oe" path="res://scenes/components/outpost/BuildingData.cs" id="3_building_data"]
+
+[sub_resource type="Resource" id="Resource_building_data"]
+script = ExtResource("3_building_data")
+LabelName = "Building"
+Description = "Interact with this building."
+OwnerText = "Welcome. What do you need?"
+BuildingTexture = ExtResource("1_8rcmu")
 
 [sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_13jms"]
 size = Vector2(64, 64)
@@ -11,7 +19,7 @@ radius = 61.03278
 
 [node name="Building" type="Node2D" unique_id=1511369869]
 script = ExtResource("2_lm4d7")
-TextureHouse = ExtResource("1_8rcmu")
+BuildingData = SubResource("Resource_building_data")
 
 [node name="SpriteHouse" type="Sprite2D" parent="." unique_id=333691828]
 texture = ExtResource("1_8rcmu")

--- a/scenes/components/outpost/buildingTemplate.tscn
+++ b/scenes/components/outpost/buildingTemplate.tscn
@@ -6,6 +6,17 @@
 [sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_13jms"]
 size = Vector2(64, 64)
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_label_panel"]
+bg_color = Color(0.08, 0.07, 0.06, 0.82)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+content_margin_left = 8.0
+content_margin_top = 3.0
+content_margin_right = 8.0
+content_margin_bottom = 3.0
+
 [sub_resource type="CircleShape2D" id="CircleShape2D_13jms"]
 radius = 61.03278
 
@@ -16,9 +27,45 @@ TextureHouse = ExtResource("1_8rcmu")
 [node name="SpriteHouse" type="Sprite2D" parent="." unique_id=333691828]
 texture = ExtResource("1_8rcmu")
 
-[node name="Sprite2D" type="Sprite2D" parent="." unique_id=735441159]
-position = Vector2(0, -56)
+[node name="ClickPanel" type="Control" parent="." unique_id=735441159]
+layout_mode = 3
+anchors_preset = 0
+offset_left = -48.0
+offset_top = -108.0
+offset_right = 48.0
+offset_bottom = -28.0
+mouse_filter = 2
+
+[node name="Icon" type="TextureRect" parent="ClickPanel" unique_id=790543333]
+layout_mode = 1
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -24.0
+offset_right = 24.0
+offset_bottom = 48.0
+grow_horizontal = 2
+mouse_filter = 2
 texture = SubResource("PlaceholderTexture2D_13jms")
+expand_mode = 1
+stretch_mode = 5
+
+[node name="LabelPanel" type="PanelContainer" parent="ClickPanel" unique_id=179570743]
+layout_mode = 1
+anchors_preset = 10
+anchor_right = 1.0
+offset_top = 52.0
+offset_bottom = 80.0
+grow_horizontal = 2
+mouse_filter = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_label_panel")
+
+[node name="Label" type="Label" parent="ClickPanel/LabelPanel" unique_id=429572716]
+layout_mode = 2
+mouse_filter = 2
+text = "Building"
+horizontal_alignment = 1
+vertical_alignment = 1
 
 [node name="Area2D" type="Area2D" parent="." unique_id=380661012]
 collision_layer = 128

--- a/scenes/components/outpost/contract_building_data.tres
+++ b/scenes/components/outpost/contract_building_data.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="BuildingData" format=3 uid="uid://dc5yw0wdd4tyc"]
+
+[ext_resource type="Script" uid="uid://enkabhmf46kb" path="res://scenes/overlays/building/BuildingOverlayButtonData.cs" id="1_2fvkw"]
+[ext_resource type="Script" uid="uid://cd5blmxgvl3oe" path="res://scenes/components/outpost/BuildingData.cs" id="1_contract"]
+
+[resource]
+script = ExtResource("1_contract")
+LabelName = "Contract"
+Description = "Choose the next contract for this run."
+OwnerText = "Contracts are waiting. Pick carefully; the outpost only pays for work that gets finished."

--- a/scenes/components/outpost/inn_building_data.tres
+++ b/scenes/components/outpost/inn_building_data.tres
@@ -1,0 +1,9 @@
+[gd_resource type="Resource" script_class="BuildingData" load_steps=2 format=3]
+
+[ext_resource type="Script" uid="uid://cd5blmxgvl3oe" path="res://scenes/components/outpost/BuildingData.cs" id="1_inn"]
+
+[resource]
+script = ExtResource("1_inn")
+LabelName = "Inn"
+Description = "Rest, recover, and prepare for the next contract."
+OwnerText = "Welcome in. Take a seat, warm up, and breathe before the road calls again."

--- a/scenes/components/outpost/storefront_building_data.tres
+++ b/scenes/components/outpost/storefront_building_data.tres
@@ -1,0 +1,21 @@
+[gd_resource type="Resource" script_class="BuildingData" load_steps=8 format=3]
+
+[ext_resource type="Script" uid="uid://cd5blmxgvl3oe" path="res://scenes/components/outpost/BuildingData.cs" id="1_building"]
+[ext_resource type="Script" uid="uid://enkabhmf46kb" path="res://scenes/overlays/building/BuildingOverlayButtonData.cs" id="2_button"]
+[ext_resource type="PackedScene" path="res://scenes/overlays/storefront/StorefrontOverlay.tscn" id="3_storefront"]
+[ext_resource type="Resource" path="res://core/items/data/iron_sword.tres" id="4_iron_sword"]
+[ext_resource type="Resource" path="res://core/items/data/health_potion.tres" id="5_health_potion"]
+[ext_resource type="Resource" path="res://core/items/data/leather_armor.tres" id="6_leather_armor"]
+
+[sub_resource type="Resource" id="Resource_shop_button"]
+script = ExtResource("2_button")
+LabelName = "Shop"
+PathController = ExtResource("3_storefront")
+
+[resource]
+script = ExtResource("1_building")
+LabelName = "Storefront"
+Description = "Buy useful supplies before leaving the outpost."
+OwnerText = "Coin on the counter, goods in the bag. Take a look before the roads take their share."
+OverlayButtons = Array[Resource]([SubResource("Resource_shop_button")])
+StorefrontItems = Array[Resource]([ExtResource("4_iron_sword"), ExtResource("5_health_potion"), ExtResource("6_leather_armor")])

--- a/scenes/components/panels/InfoPopupPanel.cs
+++ b/scenes/components/panels/InfoPopupPanel.cs
@@ -1,0 +1,62 @@
+using Godot;
+
+public partial class InfoPopupPanel : Control {
+	private const float PanelWidthRatio = 0.6f;
+	private const int PanelMinWidth = 360;
+	private const int PanelMaxWidth = 760;
+
+	[Signal]
+	public delegate void ClosedEventHandler();
+
+	private PanelContainer _panel;
+	private Label _titleLabel;
+	private TextureRect _image;
+	private RichTextLabel _bodyText;
+	private Button _okButton;
+
+	public override void _Ready() {
+		EnsureNodes();
+		UpdatePanelWidth();
+	}
+
+	private void EnsureNodes() {
+		if (_panel != null)
+			return;
+
+		_panel = GetNode<PanelContainer>("CenterContainer/Panel");
+		_titleLabel = GetNode<Label>("CenterContainer/Panel/MarginContainer/Layout/Title");
+		_image = GetNode<TextureRect>("CenterContainer/Panel/MarginContainer/Layout/Image");
+		_bodyText = GetNode<RichTextLabel>("CenterContainer/Panel/MarginContainer/Layout/BodyText");
+		_okButton = GetNode<Button>("CenterContainer/Panel/MarginContainer/Layout/OkButton");
+
+		_okButton.Pressed += OnOkPressed;
+	}
+
+	public override void _Notification(int what) {
+		if (what == NotificationResized)
+			UpdatePanelWidth();
+	}
+
+	public void ShowContent(string title, string richText, Texture2D image = null) {
+		EnsureNodes();
+		_titleLabel.Text = string.IsNullOrWhiteSpace(title) ? "Info" : title;
+		_bodyText.Text = richText ?? string.Empty;
+		_image.Texture = image;
+		_image.Visible = image != null;
+		UpdatePanelWidth();
+	}
+
+	private void UpdatePanelWidth() {
+		if (_panel == null)
+			return;
+
+		var viewportWidth = GetViewportRect().Size.X;
+		var width = Mathf.Clamp(Mathf.RoundToInt(viewportWidth * PanelWidthRatio), PanelMinWidth, PanelMaxWidth);
+		_panel.CustomMinimumSize = new Vector2(width, 0.0f);
+	}
+
+	private void OnOkPressed() {
+		EmitSignal(SignalName.Closed);
+		QueueFree();
+	}
+}

--- a/scenes/components/panels/InfoPopupPanel.tscn
+++ b/scenes/components/panels/InfoPopupPanel.tscn
@@ -1,0 +1,69 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Theme" uid="uid://2us73xfo2hnd" path="res://assets/style/DefaultTheme.tres" id="1_theme"]
+[ext_resource type="Script" path="res://scenes/components/panels/InfoPopupPanel.cs" id="2_script"]
+
+[node name="InfoPopupPanel" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 1
+theme = ExtResource("1_theme")
+script = ExtResource("2_script")
+
+[node name="CenterContainer" type="CenterContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 24.0
+offset_top = 24.0
+offset_right = -24.0
+offset_bottom = -24.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Panel" type="PanelContainer" parent="CenterContainer"]
+layout_mode = 2
+
+[node name="MarginContainer" type="MarginContainer" parent="CenterContainer/Panel"]
+layout_mode = 2
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_top = 20
+theme_override_constants/margin_right = 20
+theme_override_constants/margin_bottom = 20
+
+[node name="Layout" type="VBoxContainer" parent="CenterContainer/Panel/MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 16
+
+[node name="Title" type="Label" parent="CenterContainer/Panel/MarginContainer/Layout"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 28
+text = "Info"
+horizontal_alignment = 1
+
+[node name="Image" type="TextureRect" parent="CenterContainer/Panel/MarginContainer/Layout"]
+visible = false
+custom_minimum_size = Vector2(128, 128)
+layout_mode = 2
+size_flags_horizontal = 4
+expand_mode = 1
+stretch_mode = 5
+
+[node name="BodyText" type="RichTextLabel" parent="CenterContainer/Panel/MarginContainer/Layout"]
+custom_minimum_size = Vector2(0, 120)
+layout_mode = 2
+size_flags_horizontal = 3
+bbcode_enabled = true
+fit_content = true
+scroll_active = false
+autowrap_mode = 3
+
+[node name="OkButton" type="Button" parent="CenterContainer/Panel/MarginContainer/Layout"]
+custom_minimum_size = Vector2(0, 56)
+layout_mode = 2
+text = "OK"

--- a/scenes/components/panels/PanelGold.cs
+++ b/scenes/components/panels/PanelGold.cs
@@ -17,7 +17,7 @@ public partial class PanelGold : Control {
 		if (_label == null)
 			return;
 
-		UpdateGold(SaveNode.Get().RunData.Gold);
+		UpdateGold(SaveNode.Get()?.RunData?.Gold ?? 0);
 	}
 
 	private void OnGoldAmountChanged(int goldAmount) {

--- a/scenes/components/panels/PanelLocation.cs
+++ b/scenes/components/panels/PanelLocation.cs
@@ -12,13 +12,13 @@ public partial class PanelLocation : Control {
 	}
 
 	public void Update() {
-		var runData = SaveNode.Get().RunData;
+		var runData = SaveNode.Get()?.RunData;
 
 		if (_labelBiome != null)
-			_labelBiome.Text = FormatBiomeName(runData);
+			_labelBiome.Text = runData == null ? "Unknown" : FormatBiomeName(runData);
 
 		if (_labelLocationWave != null)
-			_labelLocationWave.Text = $"{runData.CurrentLocation} : W{runData.ContractsCompleted + 1}";
+			_labelLocationWave.Text = runData == null ? "Unknown : W0" : $"{runData.CurrentLocation} : W{runData.ContractsCompleted + 1}";
 	}
 
 	private static string FormatBiomeName(RunData runData) {

--- a/scenes/components/panels/PanelPlayerTop.cs
+++ b/scenes/components/panels/PanelPlayerTop.cs
@@ -19,6 +19,6 @@ public partial class PanelPlayerTop : Control {
 
 
 		if (_labelLevel != null)
-			_labelLevel.Text = $"Level {playerData?.Skills?.GetTotalLevel() ?? 0}";
+			_labelLevel.Text = $"Level {playerData?.GetCurrentRunLevel() ?? 0}";
 	}
 }

--- a/scenes/components/panels/PanelPlayerTop.cs
+++ b/scenes/components/panels/PanelPlayerTop.cs
@@ -11,8 +11,8 @@ public partial class PanelPlayerTop : Control {
 	}
 
 	public void Update() {
-		var runData = SaveNode.Get().RunData;
-		var playerData = runData.PlayerData;
+		var runData = SaveNode.Get()?.RunData;
+		var playerData = runData?.PlayerData;
 
 		if (_labelName != null)
 			_labelName.Text = string.IsNullOrWhiteSpace(playerData?.PlayerName) ? "Player" : playerData.PlayerName;

--- a/scenes/components/panels/PanelRunMetadata.cs
+++ b/scenes/components/panels/PanelRunMetadata.cs
@@ -26,7 +26,7 @@ public partial class PanelRunMetadata : Control {
 		SetLabelText(_labelPlayerName, string.IsNullOrWhiteSpace(playerName) ? "Player" : playerName);
 		SetLabelText(_labelBiome, runData == null ? "Unknown" : FormatBiomeName(runData));
 		SetLabelText(_labelLocation, runData == null ? "Unknown" : FormatEnumName(runData.CurrentLocation.ToString()));
-		SetLabelText(_labelCurrentLevel, runData?.PlayerData?.Skills?.GetTotalLevel().ToString() ?? "0");
+		SetLabelText(_labelCurrentLevel, runData?.PlayerData?.GetCurrentRunLevel().ToString() ?? "0");
 		SetLabelText(_labelContractsCompleted, runData?.ContractsCompleted.ToString() ?? "0");
 		SetLabelText(_labelCurrentContract, FormatCurrentContract(runData?.CurrentContract));
 	}

--- a/scenes/components/settings/SettingsDataPage.cs
+++ b/scenes/components/settings/SettingsDataPage.cs
@@ -1,0 +1,22 @@
+using Godot;
+
+public partial class SettingsDataPage : MarginContainer {
+	private Button _wipeAllDataButton;
+	private ConfirmationDialog _wipeConfirmationDialog;
+
+	public override void _Ready() {
+		_wipeAllDataButton = GetNode<Button>("Layout/WipeAllDataButton");
+		_wipeConfirmationDialog = GetNode<ConfirmationDialog>("WipeConfirmationDialog");
+
+		_wipeAllDataButton.Pressed += OnWipeAllDataPressed;
+		_wipeConfirmationDialog.Confirmed += OnWipeAllDataConfirmed;
+	}
+
+	private void OnWipeAllDataPressed() {
+		_wipeConfirmationDialog.PopupCentered();
+	}
+
+	private void OnWipeAllDataConfirmed() {
+		SaveNode.Get().WipeAllData();
+	}
+}

--- a/scenes/components/settings/SettingsDataPage.cs
+++ b/scenes/components/settings/SettingsDataPage.cs
@@ -1,17 +1,35 @@
 using Godot;
+using SaveData;
 
 public partial class SettingsDataPage : MarginContainer {
 	private const string StartMenuScenePath = "res://scenes/main/main_menu/StartMenu.tscn";
 
+	private CheckBox _firstRunTipsToggle;
 	private Button _wipeAllDataButton;
 	private ConfirmationDialog _wipeConfirmationDialog;
 
 	public override void _Ready() {
+		_firstRunTipsToggle = GetNode<CheckBox>("Layout/FirstRunTipsToggle");
 		_wipeAllDataButton = GetNode<Button>("Layout/WipeAllDataButton");
 		_wipeConfirmationDialog = GetNode<ConfirmationDialog>("WipeConfirmationDialog");
 
+		_firstRunTipsToggle.Toggled += OnFirstRunTipsToggled;
 		_wipeAllDataButton.Pressed += OnWipeAllDataPressed;
 		_wipeConfirmationDialog.Confirmed += OnWipeAllDataConfirmed;
+
+		LoadSettings();
+	}
+
+	private void LoadSettings() {
+		var settings = SaveNode.Get().SettingsData ?? new SettingsData();
+		_firstRunTipsToggle.SetPressedNoSignal(settings.EnableFirstRunTips);
+	}
+
+	private void OnFirstRunTipsToggled(bool enabled) {
+		var saveNode = SaveNode.Get();
+		saveNode.SettingsData ??= new SettingsData();
+		saveNode.SettingsData.EnableFirstRunTips = enabled;
+		saveNode.SaveSettingsData();
 	}
 
 	private void OnWipeAllDataPressed() {

--- a/scenes/components/settings/SettingsDataPage.cs
+++ b/scenes/components/settings/SettingsDataPage.cs
@@ -1,6 +1,8 @@
 using Godot;
 
 public partial class SettingsDataPage : MarginContainer {
+	private const string StartMenuScenePath = "res://scenes/main/main_menu/StartMenu.tscn";
+
 	private Button _wipeAllDataButton;
 	private ConfirmationDialog _wipeConfirmationDialog;
 
@@ -18,5 +20,7 @@ public partial class SettingsDataPage : MarginContainer {
 
 	private void OnWipeAllDataConfirmed() {
 		SaveNode.Get().WipeAllData();
+		var startMenuScene = ResourceLoader.Load<PackedScene>(StartMenuScenePath);
+		GlobalOverlay.Get()?.ChangeRootScene(startMenuScene);
 	}
 }

--- a/scenes/components/settings/SettingsDataPage.cs.uid
+++ b/scenes/components/settings/SettingsDataPage.cs.uid
@@ -1,0 +1,1 @@
+uid://bo4mmblbnh3mn

--- a/scenes/components/settings/SettingsDataPage.tscn
+++ b/scenes/components/settings/SettingsDataPage.tscn
@@ -1,0 +1,46 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Theme" uid="uid://2us73xfo2hnd" path="res://assets/style/DefaultTheme.tres" id="1_theme"]
+[ext_resource type="Script" path="res://scenes/components/settings/SettingsDataPage.cs" id="2_script"]
+
+[node name="SettingsDataPage" type="MarginContainer"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_theme")
+script = ExtResource("2_script")
+theme_override_constants/margin_left = 16
+theme_override_constants/margin_top = 16
+theme_override_constants/margin_right = 16
+theme_override_constants/margin_bottom = 16
+
+[node name="Layout" type="VBoxContainer" parent="."]
+layout_mode = 2
+theme_override_constants/separation = 12
+
+[node name="Heading" type="Label" parent="Layout"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 24
+text = "Data"
+
+[node name="Description" type="Label" parent="Layout"]
+layout_mode = 2
+text = "Manage local save data."
+
+[node name="WipeAllDataButton" type="Button" parent="Layout"]
+custom_minimum_size = Vector2(0, 56)
+layout_mode = 2
+text = "Wipe All Data"
+
+[node name="Warning" type="Label" parent="Layout"]
+layout_mode = 2
+text = "This permanently removes all saved progress and settings."
+autowrap_mode = 3
+
+[node name="WipeConfirmationDialog" type="ConfirmationDialog" parent="."]
+title = "Wipe All Data"
+ok_button_text = "Wipe Data"
+dialog_text = "This will permanently delete all saved data. This cannot be undone. Continue?"

--- a/scenes/components/settings/SettingsDataPage.tscn
+++ b/scenes/components/settings/SettingsDataPage.tscn
@@ -30,6 +30,11 @@ text = "Data"
 layout_mode = 2
 text = "Manage local save data."
 
+[node name="FirstRunTipsToggle" type="CheckBox" parent="Layout"]
+custom_minimum_size = Vector2(0, 48)
+layout_mode = 2
+text = "Enable first-run tips"
+
 [node name="WipeAllDataButton" type="Button" parent="Layout"]
 custom_minimum_size = Vector2(0, 56)
 layout_mode = 2

--- a/scenes/components/settings/SettingsSoundPage.cs
+++ b/scenes/components/settings/SettingsSoundPage.cs
@@ -1,0 +1,69 @@
+using Godot;
+using SaveData;
+
+public partial class SettingsSoundPage : MarginContainer {
+	private const string SfxBusName = "SFX";
+	private const string MusicBusName = "Music";
+
+	private HSlider _sfxSlider;
+	private Label _sfxValue;
+	private CheckBox _sfxMute;
+	private HSlider _musicSlider;
+	private Label _musicValue;
+	private CheckBox _musicMute;
+	private Button _applyButton;
+
+	public override void _Ready() {
+		_sfxSlider = GetNode<HSlider>("Layout/Controls/SfxRow/Slider");
+		_sfxValue = GetNode<Label>("Layout/Controls/SfxRow/Value");
+		_sfxMute = GetNode<CheckBox>("Layout/Controls/SfxRow/Mute");
+		_musicSlider = GetNode<HSlider>("Layout/Controls/MusicRow/Slider");
+		_musicValue = GetNode<Label>("Layout/Controls/MusicRow/Value");
+		_musicMute = GetNode<CheckBox>("Layout/Controls/MusicRow/Mute");
+		_applyButton = GetNode<Button>("Layout/ApplyButton");
+
+		_sfxSlider.ValueChanged += _ => OnControlsChanged();
+		_sfxMute.Toggled += _ => OnControlsChanged();
+		_musicSlider.ValueChanged += _ => OnControlsChanged();
+		_musicMute.Toggled += _ => OnControlsChanged();
+		_applyButton.Pressed += OnApplyPressed;
+
+		LoadFromSettings();
+	}
+
+	private void LoadFromSettings() {
+		var settings = SaveNode.Get().SettingsData ?? new SettingsData();
+
+		_sfxSlider.SetValueNoSignal(settings.SfxVolumePercent);
+		_sfxMute.SetPressedNoSignal(settings.SfxEnabled);
+		_musicSlider.SetValueNoSignal(settings.MusicVolumePercent);
+		_musicMute.SetPressedNoSignal(settings.MusicEnabled);
+
+		RefreshUi();
+		_applyButton.Disabled = true;
+	}
+
+	private void OnControlsChanged() {
+		RefreshUi();
+		_applyButton.Disabled = false;
+	}
+
+	private void RefreshUi() {
+		_sfxValue.Text = $"{Mathf.RoundToInt((float)_sfxSlider.Value)}%";
+		_musicValue.Text = $"{Mathf.RoundToInt((float)_musicSlider.Value)}%";
+	}
+
+	private void OnApplyPressed() {
+		var saveNode = SaveNode.Get();
+		saveNode.SettingsData ??= new SettingsData();
+
+		saveNode.SettingsData.SfxVolumePercent = (float)_sfxSlider.Value;
+		saveNode.SettingsData.SfxEnabled = _sfxMute.ButtonPressed;
+		saveNode.SettingsData.MusicVolumePercent = (float)_musicSlider.Value;
+		saveNode.SettingsData.MusicEnabled = _musicMute.ButtonPressed;
+
+		saveNode.ApplySettings();
+		saveNode.SaveSettingsData();
+		_applyButton.Disabled = true;
+	}
+}

--- a/scenes/components/settings/SettingsSoundPage.cs.uid
+++ b/scenes/components/settings/SettingsSoundPage.cs.uid
@@ -1,0 +1,1 @@
+uid://dwdewn81rmsfv

--- a/scenes/components/settings/SettingsSoundPage.tscn
+++ b/scenes/components/settings/SettingsSoundPage.tscn
@@ -1,6 +1,7 @@
-[gd_scene format=3]
+[gd_scene load_steps=2 format=3]
 
 [ext_resource type="Theme" uid="uid://2us73xfo2hnd" path="res://assets/style/DefaultTheme.tres" id="1_theme"]
+[ext_resource type="Script" path="res://scenes/components/settings/SettingsSoundPage.cs" id="2_script"]
 
 [node name="SettingsSoundPage" type="MarginContainer"]
 layout_mode = 3
@@ -10,6 +11,7 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("1_theme")
+script = ExtResource("2_script")
 theme_override_constants/margin_left = 16
 theme_override_constants/margin_top = 16
 theme_override_constants/margin_right = 16
@@ -26,4 +28,65 @@ text = "Sound"
 
 [node name="Description" type="Label" parent="Layout"]
 layout_mode = 2
-text = "Sound settings page placeholder."
+text = "Adjust SFX and music volume. Changes are saved when applied."
+
+[node name="Controls" type="VBoxContainer" parent="Layout"]
+layout_mode = 2
+theme_override_constants/separation = 16
+
+[node name="SfxRow" type="HBoxContainer" parent="Layout/Controls"]
+layout_mode = 2
+theme_override_constants/separation = 12
+
+[node name="Label" type="Label" parent="Layout/Controls/SfxRow"]
+custom_minimum_size = Vector2(72, 0)
+layout_mode = 2
+text = "SFX"
+
+[node name="Slider" type="HSlider" parent="Layout/Controls/SfxRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+max_value = 100.0
+value = 72.0
+
+[node name="Value" type="Label" parent="Layout/Controls/SfxRow"]
+custom_minimum_size = Vector2(48, 0)
+layout_mode = 2
+text = "72%"
+
+[node name="Mute" type="CheckBox" parent="Layout/Controls/SfxRow"]
+layout_mode = 2
+button_pressed = true
+text = ""
+
+[node name="MusicRow" type="HBoxContainer" parent="Layout/Controls"]
+layout_mode = 2
+theme_override_constants/separation = 12
+
+[node name="Label" type="Label" parent="Layout/Controls/MusicRow"]
+custom_minimum_size = Vector2(72, 0)
+layout_mode = 2
+text = "Music"
+
+[node name="Slider" type="HSlider" parent="Layout/Controls/MusicRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+max_value = 100.0
+value = 84.0
+
+[node name="Value" type="Label" parent="Layout/Controls/MusicRow"]
+custom_minimum_size = Vector2(48, 0)
+layout_mode = 2
+text = "84%"
+
+[node name="Mute" type="CheckBox" parent="Layout/Controls/MusicRow"]
+layout_mode = 2
+button_pressed = true
+text = ""
+
+[node name="ApplyButton" type="Button" parent="Layout"]
+custom_minimum_size = Vector2(0, 48)
+layout_mode = 2
+size_flags_horizontal = 0
+text = "Apply"
+disabled = true

--- a/scenes/components/settings/SettingsSoundPage.tscn
+++ b/scenes/components/settings/SettingsSoundPage.tscn
@@ -28,6 +28,8 @@ text = "Sound"
 
 [node name="Description" type="Label" parent="Layout"]
 layout_mode = 2
+size_flags_horizontal = 3
+autowrap_mode = 3
 text = "Adjust SFX and music volume. Changes are saved when applied."
 
 [node name="Controls" type="VBoxContainer" parent="Layout"]

--- a/scenes/components/settings/SettingsSoundPage.tscn
+++ b/scenes/components/settings/SettingsSoundPage.tscn
@@ -1,0 +1,29 @@
+[gd_scene format=3]
+
+[ext_resource type="Theme" uid="uid://2us73xfo2hnd" path="res://assets/style/DefaultTheme.tres" id="1_theme"]
+
+[node name="SettingsSoundPage" type="MarginContainer"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_theme")
+theme_override_constants/margin_left = 16
+theme_override_constants/margin_top = 16
+theme_override_constants/margin_right = 16
+theme_override_constants/margin_bottom = 16
+
+[node name="Layout" type="VBoxContainer" parent="."]
+layout_mode = 2
+theme_override_constants/separation = 12
+
+[node name="Heading" type="Label" parent="Layout"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 24
+text = "Sound"
+
+[node name="Description" type="Label" parent="Layout"]
+layout_mode = 2
+text = "Sound settings page placeholder."

--- a/scenes/components/settings/SettingsVideoPage.tscn
+++ b/scenes/components/settings/SettingsVideoPage.tscn
@@ -1,0 +1,29 @@
+[gd_scene format=3]
+
+[ext_resource type="Theme" uid="uid://2us73xfo2hnd" path="res://assets/style/DefaultTheme.tres" id="1_theme"]
+
+[node name="SettingsVideoPage" type="MarginContainer"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_theme")
+theme_override_constants/margin_left = 16
+theme_override_constants/margin_top = 16
+theme_override_constants/margin_right = 16
+theme_override_constants/margin_bottom = 16
+
+[node name="Layout" type="VBoxContainer" parent="."]
+layout_mode = 2
+theme_override_constants/separation = 12
+
+[node name="Heading" type="Label" parent="Layout"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 24
+text = "Video"
+
+[node name="Description" type="Label" parent="Layout"]
+layout_mode = 2
+text = "Video settings page placeholder."

--- a/scenes/components/stats/PanelStats.cs
+++ b/scenes/components/stats/PanelStats.cs
@@ -3,7 +3,17 @@ using Godot;
 public partial class PanelStats : VBoxContainer {
 	[Export] public bool UseSaveNodeData { get; set; } = true;
 	[Export] public PlayerSkillData SkillXp { get; set; } = new();
-	[Export] public bool SkillDescriptionIsClickable { get; set; } = false;
+
+	private bool _skillDescriptionIsClickable;
+
+	[Export]
+	public bool SkillDescriptionIsClickable {
+		get => _skillDescriptionIsClickable;
+		set {
+			_skillDescriptionIsClickable = value;
+			UpdateSkillRowStates();
+		}
+	}
 
 	private Label _labelStrengthValue;
 	private Label _labelAgilityValue;
@@ -15,7 +25,8 @@ public partial class PanelStats : VBoxContainer {
 		_labelAgilityValue = GetNodeOrNull<Label>("StatAgi/LabelValue");
 		_labelArcanaValue = GetNodeOrNull<Label>("StatArc/LabelValue");
 		_labelVitalityValue = GetNodeOrNull<Label>("StatVit/LabelValue");
-		ConfigureSkillRows();
+		ConnectSkillRows();
+		UpdateSkillRowStates();
 
 		Update();
 	}
@@ -34,14 +45,42 @@ public partial class PanelStats : VBoxContainer {
 			label.Text = text;
 	}
 
-	private void ConfigureSkillRows() {
-		ConfigureSkillRow("StatStr", "Strength", "Strength improves direct physical power.");
-		ConfigureSkillRow("StatAgi", "Agility", "Agility improves speed and dexterity.");
-		ConfigureSkillRow("StatArc", "Arcana", "Arcana improves magical power and effects.");
-		ConfigureSkillRow("StatVit", "Vitality", "Vitality improves survivability and endurance.");
+	private void ConnectSkillRows() {
+		ConnectSkillRow("StatStr", "Strength", "Strength improves direct physical power.");
+		ConnectSkillRow("StatAgi", "Agility", "Agility improves speed and dexterity.");
+		ConnectSkillRow("StatArc", "Arcana", "Arcana improves magical power and effects.");
+		ConnectSkillRow("StatVit", "Vitality", "Vitality improves survivability and endurance.");
 	}
 
-	private void ConfigureSkillRow(string path, string title, string description) {
+	private void UpdateSkillRowStates() {
+		ApplySkillRowState("StatStr", "Strength improves direct physical power.");
+		ApplySkillRowState("StatAgi", "Agility improves speed and dexterity.");
+		ApplySkillRowState("StatArc", "Arcana improves magical power and effects.");
+		ApplySkillRowState("StatVit", "Vitality improves survivability and endurance.");
+	}
+
+	private void ConnectSkillRow(string path, string title, string description) {
+		var row = GetNodeOrNull<Control>(path);
+		if (row == null)
+			return;
+
+		foreach (var child in row.GetChildren()) {
+			if (child is Control controlChild)
+				controlChild.MouseFilter = MouseFilterEnum.Ignore;
+		}
+
+		row.GuiInput += inputEvent => {
+			if (!SkillDescriptionIsClickable)
+				return;
+
+			if (inputEvent is not InputEventMouseButton { Pressed: true, ButtonIndex: MouseButton.Left })
+				return;
+
+			GlobalOverlay.Get()?.ShowBlurredPopup(title, description);
+		};
+	}
+
+	private void ApplySkillRowState(string path, string description) {
 		var row = GetNodeOrNull<Control>(path);
 		if (row == null)
 			return;
@@ -49,22 +88,6 @@ public partial class PanelStats : VBoxContainer {
 		row.MouseDefaultCursorShape = SkillDescriptionIsClickable
 			? CursorShape.PointingHand
 			: CursorShape.Arrow;
-		row.TooltipText = SkillDescriptionIsClickable ? description : string.Empty;
 		row.Modulate = SkillDescriptionIsClickable ? new Color(0.55f, 1.0f, 0.55f, 1.0f) : Colors.White;
-
-		foreach (var child in row.GetChildren()) {
-			if (child is Control controlChild)
-				controlChild.MouseFilter = MouseFilterEnum.Ignore;
-		}
-
-		if (!SkillDescriptionIsClickable)
-			return;
-
-		row.GuiInput += inputEvent => {
-			if (inputEvent is not InputEventMouseButton { Pressed: true, ButtonIndex: MouseButton.Left })
-				return;
-
-			GlobalOverlay.Get()?.ShowBlurredPopup(title, description);
-		};
 	}
 }

--- a/scenes/components/stats/PanelStats.cs
+++ b/scenes/components/stats/PanelStats.cs
@@ -3,6 +3,7 @@ using Godot;
 public partial class PanelStats : VBoxContainer {
 	[Export] public bool UseSaveNodeData { get; set; } = true;
 	[Export] public PlayerSkillData SkillXp { get; set; } = new();
+	[Export] public bool SkillDescriptionIsClickable { get; set; } = false;
 
 	private Label _labelStrengthValue;
 	private Label _labelAgilityValue;
@@ -14,6 +15,7 @@ public partial class PanelStats : VBoxContainer {
 		_labelAgilityValue = GetNodeOrNull<Label>("StatAgi/LabelValue");
 		_labelArcanaValue = GetNodeOrNull<Label>("StatArc/LabelValue");
 		_labelVitalityValue = GetNodeOrNull<Label>("StatVit/LabelValue");
+		ConfigureSkillRows();
 
 		Update();
 	}
@@ -30,5 +32,39 @@ public partial class PanelStats : VBoxContainer {
 	private static void SetLabelText(Label label, string text) {
 		if (label != null)
 			label.Text = text;
+	}
+
+	private void ConfigureSkillRows() {
+		ConfigureSkillRow("StatStr", "Strength", "Strength improves direct physical power.");
+		ConfigureSkillRow("StatAgi", "Agility", "Agility improves speed and dexterity.");
+		ConfigureSkillRow("StatArc", "Arcana", "Arcana improves magical power and effects.");
+		ConfigureSkillRow("StatVit", "Vitality", "Vitality improves survivability and endurance.");
+	}
+
+	private void ConfigureSkillRow(string path, string title, string description) {
+		var row = GetNodeOrNull<Control>(path);
+		if (row == null)
+			return;
+
+		row.MouseDefaultCursorShape = SkillDescriptionIsClickable
+			? CursorShape.PointingHand
+			: CursorShape.Arrow;
+		row.TooltipText = SkillDescriptionIsClickable ? description : string.Empty;
+		row.Modulate = SkillDescriptionIsClickable ? new Color(0.55f, 1.0f, 0.55f, 1.0f) : Colors.White;
+
+		foreach (var child in row.GetChildren()) {
+			if (child is Control controlChild)
+				controlChild.MouseFilter = MouseFilterEnum.Ignore;
+		}
+
+		if (!SkillDescriptionIsClickable)
+			return;
+
+		row.GuiInput += inputEvent => {
+			if (inputEvent is not InputEventMouseButton { Pressed: true, ButtonIndex: MouseButton.Left })
+				return;
+
+			GlobalOverlay.Get()?.ShowBlurredPopup(title, description);
+		};
 	}
 }

--- a/scenes/main/character_select/CharacterSelectNew.cs
+++ b/scenes/main/character_select/CharacterSelectNew.cs
@@ -1,11 +1,16 @@
 using Godot;
 
 public partial class CharacterSelectNew : Control {
+	private Label _chooseStartingCharacterLabel;
+
 	public override void _Ready() {
+		_chooseStartingCharacterLabel = GetNodeOrNull<Label>("ChooseStartingCharacterLabel");
+
 		var startCharacters = SaveNode.Get().StartCharacters;
 		SetCharacter("HBoxContainer/PanelStats/NewCharacterComponent", startCharacters, 0);
 		SetCharacter("HBoxContainer/PanelGear/NewCharacterComponent", startCharacters, 1);
 		SetCharacter("HBoxContainer/PanelButton/NewCharacterComponent", startCharacters, 2);
+		UpdateFirstRunTips();
 	}
 
 	private void SetCharacter(string path, PlayerData[] startCharacters, int index) {
@@ -14,5 +19,25 @@ public partial class CharacterSelectNew : Control {
 
 		var component = GetNodeOrNull<NewCharacterComponent>(path);
 		component?.SetPlayerData(startCharacters[index]);
+	}
+
+	private void UpdateFirstRunTips() {
+		var saveNode = SaveNode.Get();
+		var showTips = saveNode.SettingsData?.EnableFirstRunTips ?? true;
+		const string labelText = "Choose a starting character.";
+
+		if (_chooseStartingCharacterLabel != null) {
+			_chooseStartingCharacterLabel.Text = labelText;
+			_chooseStartingCharacterLabel.Visible = true;
+		}
+
+		if (!showTips)
+			return;
+
+		CallDeferred(MethodName.ShowFirstRunTipsDialog);
+	}
+
+	private void ShowFirstRunTipsDialog() {
+		GlobalOverlay.Get()?.ShowBlurredPopup("Character Select", "Choose a starting character. Green stats can be clicked to read what each stat means.");
 	}
 }

--- a/scenes/main/character_select/RunOverview.cs
+++ b/scenes/main/character_select/RunOverview.cs
@@ -8,7 +8,17 @@ public partial class RunOverview : Control {
 	public override void _Ready() {
 		SetButtonScene("HBoxContainer/PanelButton/VBoxContainer/ContinueButton", OutpostScenePath);
 		SetButtonScene("HBoxContainer/PanelButton/VBoxContainer/NewRunButton", NewCharacterScenePath);
+		UpdateNewRunButtonVisibility();
 		SetButtonScene("BackButton", MainMenuScenePath);
+	}
+
+	private void UpdateNewRunButtonVisibility() {
+		var newRunButton = GetNodeOrNull<Button>("HBoxContainer/PanelButton/VBoxContainer/NewRunButton");
+		if (newRunButton == null)
+			return;
+
+		var runData = SaveNode.Get()?.RunData;
+		newRunButton.Visible = runData?.PlayerData == null || runData.ContractsCompleted >= 1;
 	}
 
 	private void SetButtonScene(string buttonPath, string scenePath) {

--- a/scenes/main/character_select/characterSelectNew.tscn
+++ b/scenes/main/character_select/characterSelectNew.tscn
@@ -16,6 +16,20 @@ grow_vertical = 2
 theme = ExtResource("1_jcnjm")
 script = ExtResource("1_xudq2")
 
+[node name="ChooseStartingCharacterLabel" type="Label" parent="." unique_id=138700001]
+visible = false
+layout_mode = 1
+anchors_preset = 10
+anchor_right = 1.0
+offset_left = 40.0
+offset_top = 20.0
+offset_right = -40.0
+offset_bottom = 56.0
+grow_horizontal = 2
+horizontal_alignment = 1
+vertical_alignment = 1
+autowrap_mode = 3
+
 [node name="HBoxContainer" type="HBoxContainer" parent="." unique_id=309868253]
 layout_mode = 1
 anchors_preset = 15
@@ -27,6 +41,7 @@ offset_right = -29.0
 offset_bottom = -66.0
 grow_horizontal = 2
 grow_vertical = 2
+theme_override_constants/separation = 12
 alignment = 1
 
 [node name="PanelStats" type="Panel" parent="HBoxContainer" unique_id=535298550]
@@ -52,6 +67,7 @@ size_flags_horizontal = 3
 layout_mode = 1
 
 [node name="BackButton" type="Button" parent="." unique_id=2147109797]
+modulate = Color(1, 0.15, 0.15, 1)
 custom_minimum_size = Vector2(56, 56)
 layout_mode = 1
 anchors_preset = 1
@@ -62,10 +78,9 @@ offset_top = 24.0
 offset_right = -24.0
 offset_bottom = 80.0
 grow_horizontal = 0
-modulate = Color(1, 0.15, 0.15, 1)
 theme_override_colors/font_color = Color(1, 1, 1, 1)
-theme_override_colors/font_hover_color = Color(1, 1, 1, 1)
 theme_override_colors/font_pressed_color = Color(1, 1, 1, 1)
+theme_override_colors/font_hover_color = Color(1, 1, 1, 1)
 text = "X"
 script = ExtResource("1_2t5lb")
 SceneToLoad = ExtResource("2_blqyk")

--- a/scenes/main/main_menu/StartMenu.tscn
+++ b/scenes/main/main_menu/StartMenu.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="Theme" uid="uid://2us73xfo2hnd" path="res://assets/style/DefaultTheme.tres" id="1_f84f2"]
 [ext_resource type="Script" uid="uid://c43vpjm3f8d4i" path="res://core/ui/ControlGotoScene.cs" id="2_2xbjv"]
 [ext_resource type="Script" uid="uid://dioyjiomklqq1" path="res://scenes/main/main_menu/StartMenu.cs" id="2_ks6tn"]
-[ext_resource type="PackedScene" path="res://scenes/main/character_select/RunOverview.tscn" id="3_fkdaq"]
+[ext_resource type="PackedScene" uid="uid://c1fhu7u3k6v5a" path="res://scenes/main/character_select/RunOverview.tscn" id="3_fkdaq"]
 [ext_resource type="Script" uid="uid://bn7lsfu8p7umr" path="res://core/ui/OpenOverlay.cs" id="3_w37gf"]
 [ext_resource type="PackedScene" path="res://scenes/overlays/main_menu/SettingsOverlay.tscn" id="4_settings"]
 [ext_resource type="PackedScene" uid="uid://bewk1qfwxhqaf" path="res://scenes/overlays/main_menu/CodexOverlay.tscn" id="5_codex"]

--- a/scenes/main/main_menu/StartMenu.tscn
+++ b/scenes/main/main_menu/StartMenu.tscn
@@ -51,24 +51,6 @@ script = ExtResource("3_w37gf")
 OverlayScene = ExtResource("4_settings")
 metadata/_custom_type_script = "uid://bn7lsfu8p7umr"
 
-[node name="ControlGotoScene" type="Control" parent="." unique_id=1576324752]
-layout_mode = 1
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -486.0
-offset_top = -289.125
-offset_right = 486.0
-offset_bottom = 193.125
-grow_horizontal = 2
-grow_vertical = 2
-script = ExtResource("2_2xbjv")
-SceneToLoad = ExtResource("3_fkdaq")
-ChangeScene = true
-metadata/_custom_type_script = "uid://c43vpjm3f8d4i"
-
 [node name="Label" type="Label" parent="." unique_id=1277470694]
 layout_mode = 1
 anchors_preset = 8
@@ -190,3 +172,21 @@ theme_override_font_sizes/font_size = 108
 text = "Triad of Descent"
 label_settings = SubResource("LabelSettings_ks6tn")
 horizontal_alignment = 1
+
+[node name="ControlGotoScene" type="Control" parent="." unique_id=1576324752]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -486.0
+offset_top = -289.125
+offset_right = 486.0
+offset_bottom = 193.125
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("2_2xbjv")
+SceneToLoad = ExtResource("3_fkdaq")
+ChangeScene = true
+metadata/_custom_type_script = "uid://c43vpjm3f8d4i"

--- a/scenes/main/outpost/Outpost.cs
+++ b/scenes/main/outpost/Outpost.cs
@@ -1,0 +1,21 @@
+using Godot;
+
+public partial class Outpost : Node {
+	public override void _Ready() {
+		UpdateFirstRunGuidance();
+	}
+
+	private void UpdateFirstRunGuidance() {
+		var saveNode = SaveNode.Get();
+		var showTips = saveNode.SettingsData?.EnableFirstRunTips ?? true;
+
+		if (!showTips)
+			return;
+
+		CallDeferred(MethodName.ShowFirstRunOutpostDialog);
+	}
+
+	private void ShowFirstRunOutpostDialog() {
+		GlobalOverlay.Get()?.ShowBlurredPopup("Village", "You are in the village. Tap buildings to enter them and see what they offer. The buttons at the bottom open your inventory, character, and codex. Press the contract building to start your adventure.");
+	}
+}

--- a/scenes/main/outpost/Outpost.tscn
+++ b/scenes/main/outpost/Outpost.tscn
@@ -4,12 +4,14 @@
 [ext_resource type="Script" uid="uid://cojt55fjm1e35" path="res://core/ui/ChangeOverlayScene.cs" id="1_bgakn"]
 [ext_resource type="Script" uid="uid://bn7lsfu8p7umr" path="res://core/ui/OpenOverlay.cs" id="2_6amyp"]
 [ext_resource type="Theme" uid="uid://2us73xfo2hnd" path="res://assets/style/DefaultTheme.tres" id="2_vumbe"]
+[ext_resource type="Resource" path="res://scenes/components/outpost/contract_building_data.tres" id="3_contract_data"]
+[ext_resource type="Script" uid="uid://gifxs8nfold4" path="res://scenes/main/outpost/OutpostBuildings.cs" id="4_3fain"]
 [ext_resource type="PackedScene" uid="uid://b1kf2xl55ull2" path="res://scenes/components/panels/PanelGold.tscn" id="4_b38rb"]
+[ext_resource type="Resource" path="res://scenes/components/outpost/inn_building_data.tres" id="4_inn_data"]
 [ext_resource type="PackedScene" uid="uid://cpis4v08h0ebo" path="res://scenes/components/panels/PanelLocation.tscn" id="5_wqu6w"]
 [ext_resource type="PackedScene" uid="uid://fqd6rdrheta3" path="res://scenes/components/panels/PanelPlayerTop.tscn" id="6_imbua"]
-[ext_resource type="PackedScene" uid="uid://hwrt00phvgys" path="res://scenes/overlays/building/BuildingOverlay.tscn" id="8_nw8ct"]
 [ext_resource type="PackedScene" uid="uid://ctji244a31gb0" path="res://scenes/main/main_menu/StartMenu.tscn" id="9_bgakn"]
-[ext_resource type="PackedScene" path="res://scenes/overlays/main_menu/CodexOverlay.tscn" id="10_codex"]
+[ext_resource type="PackedScene" uid="uid://bewk1qfwxhqaf" path="res://scenes/overlays/main_menu/CodexOverlay.tscn" id="10_codex"]
 [ext_resource type="PackedScene" path="res://scenes/overlays/main_menu/SettingsOverlay.tscn" id="11_settings"]
 [ext_resource type="PackedScene" uid="uid://b8o2ydskyt0q1" path="res://scenes/overlays/inventory/InventoryOverlay.tscn" id="12_inventory"]
 [ext_resource type="PackedScene" path="res://scenes/overlays/character/CharacterOverlay.tscn" id="13_character"]
@@ -141,21 +143,26 @@ metadata/_custom_type_script = "uid://bn7lsfu8p7umr"
 
 [node name="World" type="Node2D" parent="." unique_id=1723193871]
 
-[node name="Building" parent="World" unique_id=1511369869 instance=ExtResource("1_7r7tj")]
-position = Vector2(204, 393)
-OverlayScene = ExtResource("8_nw8ct")
+[node name="OutpostBuildings" type="Node2D" parent="World" unique_id=1143238284]
+script = ExtResource("4_3fain")
+BuildingTemplateScene = ExtResource("1_7r7tj")
 
-[node name="Building2" parent="World" unique_id=780541550 instance=ExtResource("1_7r7tj")]
+[node name="RandomSlot1" type="Node2D" parent="World/OutpostBuildings" unique_id=1511369869]
+position = Vector2(204, 393)
+
+[node name="RandomSlot2" type="Node2D" parent="World/OutpostBuildings" unique_id=780541550]
 position = Vector2(414, 252)
 
-[node name="Building3" parent="World" unique_id=1997029538 instance=ExtResource("1_7r7tj")]
-position = Vector2(575, 478)
-
-[node name="Building4" parent="World" unique_id=1919299272 instance=ExtResource("1_7r7tj")]
+[node name="RandomSlot3" type="Node2D" parent="World/OutpostBuildings" unique_id=1919299272]
 position = Vector2(721, 259)
+
+[node name="Contract" parent="World" unique_id=1997029538 instance=ExtResource("1_7r7tj")]
+position = Vector2(575, 478)
+BuildingData = ExtResource("3_contract_data")
+
+[node name="Inn" parent="World" unique_id=1162120890 instance=ExtResource("1_7r7tj")]
+position = Vector2(891, 402)
+BuildingData = ExtResource("4_inn_data")
 
 [node name="Camera2D" type="Camera2D" parent="World" unique_id=2010866043]
 position = Vector2(576, 324)
-
-[node name="Building5" parent="World" unique_id=1162120890 instance=ExtResource("1_7r7tj")]
-position = Vector2(891, 402)

--- a/scenes/main/outpost/Outpost.tscn
+++ b/scenes/main/outpost/Outpost.tscn
@@ -15,6 +15,7 @@
 [ext_resource type="PackedScene" path="res://scenes/overlays/main_menu/SettingsOverlay.tscn" id="11_settings"]
 [ext_resource type="PackedScene" uid="uid://b8o2ydskyt0q1" path="res://scenes/overlays/inventory/InventoryOverlay.tscn" id="12_inventory"]
 [ext_resource type="PackedScene" path="res://scenes/overlays/character/CharacterOverlay.tscn" id="13_character"]
+[ext_resource type="Script" path="res://scenes/main/outpost/Outpost.cs" id="14_outpost_script"]
 
 [sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_bgakn"]
 
@@ -23,6 +24,7 @@
 [sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_6amyp"]
 
 [node name="Root" type="Node" unique_id=1748825370]
+script = ExtResource("14_outpost_script")
 
 [node name="CanvasLayer" type="CanvasLayer" parent="." unique_id=812051596]
 

--- a/scenes/main/outpost/OutpostBuildings.cs
+++ b/scenes/main/outpost/OutpostBuildings.cs
@@ -13,6 +13,9 @@ public partial class OutpostBuildings : Node2D {
 
 	public override void _Ready() {
 		var saveNode = SaveNode.Get();
+		if (saveNode.RunData == null)
+			return;
+
 		var buildings = saveNode.RunData.OutpostBuildings;
 
 		if (buildings == null || buildings.Count != GetChildCount()) {

--- a/scenes/main/outpost/OutpostBuildings.cs
+++ b/scenes/main/outpost/OutpostBuildings.cs
@@ -1,0 +1,68 @@
+using Godot;
+using Godot.Collections;
+
+public partial class OutpostBuildings : Node2D {
+	[Export] public PackedScene BuildingTemplateScene { get; set; }
+
+	public override void _Ready() {
+		var saveNode = SaveNode.Get();
+		var buildings = saveNode.RunData.OutpostBuildings;
+
+		if (buildings == null) {
+			buildings = GenerateMockBuildings();
+			saveNode.RunData.OutpostBuildings = buildings;
+			saveNode.SaveRunData();
+		}
+
+		GenerateBuildings(buildings);
+	}
+
+	private void GenerateBuildings(Array<BuildingData> buildings) {
+		if (BuildingTemplateScene == null) {
+			GD.PushWarning($"{nameof(OutpostBuildings)} on '{Name}' has no building template configured.");
+			return;
+		}
+
+		var slotIndex = 0;
+		foreach (var buildingData in buildings) {
+			if (buildingData == null)
+				continue;
+
+			var slot = GetSlot(slotIndex);
+			if (slot == null)
+				break;
+
+			var building = BuildingTemplateScene.Instantiate<BuildingTemplate>();
+			building.BuildingData = buildingData;
+			slot.AddChild(building);
+			slotIndex++;
+		}
+	}
+
+	private Node2D GetSlot(int index) {
+		if (index < 0 || index >= GetChildCount())
+			return null;
+
+		return GetChild(index) as Node2D;
+	}
+
+	private static Array<BuildingData> GenerateMockBuildings() {
+		var placeholderTexture = new PlaceholderTexture2D { Size = new Vector2I(64, 64) };
+
+		return new Array<BuildingData> {
+			new() {
+				LabelName = "Blacksmith",
+				Description = "Forge, repair, and improve equipment.",
+				OwnerText = "Steel remembers every strike. Bring me coin and materials, and I'll make your gear remember victory.",
+				BuildingTexture = placeholderTexture,
+				OwnerTexture = placeholderTexture,
+				OverlayButtons = new Array<BuildingOverlayButtonData> {
+					new() {
+						IconPath = "",
+						LabelName = "Forge"
+					}
+				}
+			}
+		};
+	}
+}

--- a/scenes/main/outpost/OutpostBuildings.cs
+++ b/scenes/main/outpost/OutpostBuildings.cs
@@ -48,6 +48,7 @@ public partial class OutpostBuildings : Node2D {
 
 	private static Array<BuildingData> GenerateMockBuildings() {
 		var placeholderTexture = new PlaceholderTexture2D { Size = new Vector2I(64, 64) };
+		var storefrontScene = GD.Load<PackedScene>("res://scenes/overlays/storefront/StorefrontOverlay.tscn");
 
 		return new Array<BuildingData> {
 			new() {
@@ -60,7 +61,17 @@ public partial class OutpostBuildings : Node2D {
 					new() {
 						IconPath = "",
 						LabelName = "Forge"
+					},
+					new() {
+						IconPath = "",
+						LabelName = "Shop",
+						PathController = storefrontScene
 					}
+				},
+				StorefrontItems = new Array<ItemBase> {
+					new ItemBase("Iron Sword", null, placeholderTexture, 1, 100),
+					new ItemBase("Repair Kit", null, placeholderTexture, 5, 40),
+					new ItemBase("Steel Buckler", null, placeholderTexture, 1, 140)
 				}
 			}
 		};

--- a/scenes/main/outpost/OutpostBuildings.cs
+++ b/scenes/main/outpost/OutpostBuildings.cs
@@ -2,8 +2,7 @@ using Godot;
 using Godot.Collections;
 
 public partial class OutpostBuildings : Node2D {
-	private const int MinGeneratedBuildings = 1;
-	private const int MaxGeneratedBuildings = 3;
+	private const int MinGeneratedBuildings = 0;
 	private static readonly string[] PossibleBuildingPaths = {
 		"res://core/buildings/data/blacksmith.tres",
 		"res://core/buildings/data/jeweler.tres",
@@ -16,8 +15,8 @@ public partial class OutpostBuildings : Node2D {
 		var saveNode = SaveNode.Get();
 		var buildings = saveNode.RunData.OutpostBuildings;
 
-		if (buildings == null) {
-			buildings = GenerateMockBuildings();
+		if (buildings == null || buildings.Count != GetChildCount()) {
+			buildings = GenerateOutpostBuildings();
 			saveNode.RunData.OutpostBuildings = buildings;
 			saveNode.SaveRunData();
 		}
@@ -31,8 +30,8 @@ public partial class OutpostBuildings : Node2D {
 			return;
 		}
 
-		var slotIndex = 0;
-		foreach (var buildingData in buildings) {
+		for (var slotIndex = 0; slotIndex < buildings.Count; slotIndex++) {
+			var buildingData = buildings[slotIndex];
 			if (buildingData == null)
 				continue;
 
@@ -43,7 +42,6 @@ public partial class OutpostBuildings : Node2D {
 			var building = BuildingTemplateScene.Instantiate<BuildingTemplate>();
 			building.BuildingData = buildingData;
 			slot.AddChild(building);
-			slotIndex++;
 		}
 	}
 
@@ -54,23 +52,39 @@ public partial class OutpostBuildings : Node2D {
 		return GetChild(index) as Node2D;
 	}
 
-	private static Array<BuildingData> GenerateMockBuildings() {
+	private Array<BuildingData> GenerateOutpostBuildings() {
 		var buildings = new Array<BuildingData>();
 		var remainingPaths = new Array<string>(PossibleBuildingPaths);
+		var remainingSlots = new Array<int>();
 		var random = new RandomNumberGenerator();
 		random.Randomize();
-		var buildingCount = random.RandiRange(MinGeneratedBuildings, Mathf.Min(MaxGeneratedBuildings, remainingPaths.Count));
+
+		for (var slotIndex = 0; slotIndex < GetChildCount(); slotIndex++) {
+			buildings.Add(null);
+			remainingSlots.Add(slotIndex);
+		}
+
+		var maxBuildingCount = Mathf.Min(remainingPaths.Count, remainingSlots.Count);
+		var buildingCount = random.RandiRange(MinGeneratedBuildings, maxBuildingCount);
 
 		for (var i = 0; i < buildingCount; i++) {
 			var pathIndex = random.RandiRange(0, remainingPaths.Count - 1);
 			var buildingPath = remainingPaths[pathIndex];
 			remainingPaths.RemoveAt(pathIndex);
+			var slotIndex = TakeRandomSlot(remainingSlots, random);
 
 			var buildingData = ResourceLoader.Load<BuildingData>(buildingPath);
 			if (buildingData != null)
-				buildings.Add(buildingData);
+				buildings[slotIndex] = buildingData;
 		}
 
 		return buildings;
+	}
+
+	private static int TakeRandomSlot(Array<int> slots, RandomNumberGenerator random) {
+		var slotListIndex = random.RandiRange(0, slots.Count - 1);
+		var slotIndex = slots[slotListIndex];
+		slots.RemoveAt(slotListIndex);
+		return slotIndex;
 	}
 }

--- a/scenes/main/outpost/OutpostBuildings.cs
+++ b/scenes/main/outpost/OutpostBuildings.cs
@@ -2,6 +2,14 @@ using Godot;
 using Godot.Collections;
 
 public partial class OutpostBuildings : Node2D {
+	private const int MinGeneratedBuildings = 1;
+	private const int MaxGeneratedBuildings = 3;
+	private static readonly string[] PossibleBuildingPaths = {
+		"res://core/buildings/data/blacksmith.tres",
+		"res://core/buildings/data/jeweler.tres",
+		"res://core/buildings/data/general_goods.tres"
+	};
+
 	[Export] public PackedScene BuildingTemplateScene { get; set; }
 
 	public override void _Ready() {
@@ -47,33 +55,22 @@ public partial class OutpostBuildings : Node2D {
 	}
 
 	private static Array<BuildingData> GenerateMockBuildings() {
-		var placeholderTexture = new PlaceholderTexture2D { Size = new Vector2I(64, 64) };
-		var storefrontScene = GD.Load<PackedScene>("res://scenes/overlays/storefront/StorefrontOverlay.tscn");
+		var buildings = new Array<BuildingData>();
+		var remainingPaths = new Array<string>(PossibleBuildingPaths);
+		var random = new RandomNumberGenerator();
+		random.Randomize();
+		var buildingCount = random.RandiRange(MinGeneratedBuildings, Mathf.Min(MaxGeneratedBuildings, remainingPaths.Count));
 
-		return new Array<BuildingData> {
-			new() {
-				LabelName = "Blacksmith",
-				Description = "Forge, repair, and improve equipment.",
-				OwnerText = "Steel remembers every strike. Bring me coin and materials, and I'll make your gear remember victory.",
-				BuildingTexture = placeholderTexture,
-				OwnerTexture = placeholderTexture,
-				OverlayButtons = new Array<BuildingOverlayButtonData> {
-					new() {
-						IconPath = "",
-						LabelName = "Forge"
-					},
-					new() {
-						IconPath = "",
-						LabelName = "Shop",
-						PathController = storefrontScene
-					}
-				},
-				StorefrontItems = new Array<ItemBase> {
-					new ItemBase("Iron Sword", null, placeholderTexture, 1, 100),
-					new ItemBase("Repair Kit", null, placeholderTexture, 5, 40),
-					new ItemBase("Steel Buckler", null, placeholderTexture, 1, 140)
-				}
-			}
-		};
+		for (var i = 0; i < buildingCount; i++) {
+			var pathIndex = random.RandiRange(0, remainingPaths.Count - 1);
+			var buildingPath = remainingPaths[pathIndex];
+			remainingPaths.RemoveAt(pathIndex);
+
+			var buildingData = ResourceLoader.Load<BuildingData>(buildingPath);
+			if (buildingData != null)
+				buildings.Add(buildingData);
+		}
+
+		return buildings;
 	}
 }

--- a/scenes/main/outpost/OutpostBuildings.cs
+++ b/scenes/main/outpost/OutpostBuildings.cs
@@ -1,5 +1,6 @@
 using Godot;
 using Godot.Collections;
+using SaveData;
 
 public partial class OutpostBuildings : Node2D {
 	private const int MinGeneratedBuildings = 0;
@@ -16,11 +17,14 @@ public partial class OutpostBuildings : Node2D {
 		if (saveNode.RunData == null)
 			return;
 
-		var buildings = saveNode.RunData.OutpostBuildings;
+		var outpostData = saveNode.RunData.OutpostData;
+		var buildings = outpostData?.Buildings;
 
 		if (buildings == null || buildings.Count != GetChildCount()) {
 			buildings = GenerateOutpostBuildings();
-			saveNode.RunData.OutpostBuildings = buildings;
+			saveNode.RunData.OutpostData = new OutpostData {
+				Buildings = buildings
+			};
 			saveNode.SaveRunData();
 		}
 

--- a/scenes/main/outpost/OutpostBuildings.cs.uid
+++ b/scenes/main/outpost/OutpostBuildings.cs.uid
@@ -1,0 +1,1 @@
+uid://gifxs8nfold4

--- a/scenes/overlays/building/BuildingOverlay.cs
+++ b/scenes/overlays/building/BuildingOverlay.cs
@@ -1,0 +1,12 @@
+using Godot;
+
+public partial class BuildingOverlay : Control {
+	public void Update(BuildingData buildingData) {
+		if (buildingData == null) {
+			GD.PushWarning($"{nameof(BuildingOverlay)} received no building data.");
+			return;
+		}
+
+		buildingData.Generate(this);
+	}
+}

--- a/scenes/overlays/building/BuildingOverlay.cs.uid
+++ b/scenes/overlays/building/BuildingOverlay.cs.uid
@@ -1,0 +1,1 @@
+uid://bmqhj3sdl0fnb

--- a/scenes/overlays/building/BuildingOverlay.tscn
+++ b/scenes/overlays/building/BuildingOverlay.tscn
@@ -1,11 +1,9 @@
 [gd_scene format=3 uid="uid://hwrt00phvgys"]
 
 [ext_resource type="Theme" uid="uid://2us73xfo2hnd" path="res://assets/style/DefaultTheme.tres" id="1_01qpf"]
-[ext_resource type="Script" uid="uid://bn7lsfu8p7umr" path="res://core/ui/OpenOverlay.cs" id="2_cjdsb"]
+[ext_resource type="Script" uid="uid://bmqhj3sdl0fnb" path="res://scenes/overlays/building/BuildingOverlay.cs" id="2_qrp73"]
 [ext_resource type="Script" uid="uid://b5nexivgcopri" path="res://core/ui/CloseOverlay.cs" id="3_66bgr"]
 [ext_resource type="PackedScene" uid="uid://cbit1hetoxuyt" path="res://scenes/components/panels/PanelBuilding.tscn" id="4_mlke7"]
-
-[sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_urxyx"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_01qpf"]
 
@@ -17,6 +15,7 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("1_01qpf")
+script = ExtResource("2_qrp73")
 
 [node name="Panel" type="ColorRect" parent="." unique_id=164256524]
 layout_mode = 1
@@ -42,45 +41,6 @@ grow_vertical = 0
 theme_override_constants/separation = 16
 metadata/_edit_lock_ = true
 
-[node name="BtnOne" type="Button" parent="BottomUI" unique_id=1807113178]
-custom_minimum_size = Vector2(80, 80)
-layout_mode = 2
-size_flags_horizontal = 3
-text = "$Btn1"
-icon = SubResource("PlaceholderTexture2D_urxyx")
-icon_alignment = 1
-vertical_icon_alignment = 0
-expand_icon = true
-script = ExtResource("2_cjdsb")
-metadata/_custom_type_script = "uid://bn7lsfu8p7umr"
-metadata/_edit_lock_ = true
-
-[node name="BtnTwo" type="Button" parent="BottomUI" unique_id=959787783]
-custom_minimum_size = Vector2(80, 80)
-layout_mode = 2
-size_flags_horizontal = 3
-text = "$Btn2"
-icon = SubResource("PlaceholderTexture2D_urxyx")
-icon_alignment = 1
-vertical_icon_alignment = 0
-expand_icon = true
-script = ExtResource("2_cjdsb")
-metadata/_custom_type_script = "uid://bn7lsfu8p7umr"
-metadata/_edit_lock_ = true
-
-[node name="BtnTree" type="Button" parent="BottomUI" unique_id=1175373288]
-custom_minimum_size = Vector2(80, 80)
-layout_mode = 2
-size_flags_horizontal = 3
-text = "$Btn3"
-icon = SubResource("PlaceholderTexture2D_urxyx")
-icon_alignment = 1
-vertical_icon_alignment = 0
-expand_icon = true
-script = ExtResource("2_cjdsb")
-metadata/_custom_type_script = "uid://bn7lsfu8p7umr"
-metadata/_edit_lock_ = true
-
 [node name="PanelBuilding" parent="." unique_id=2082076853 instance=ExtResource("4_mlke7")]
 layout_mode = 1
 offset_left = 24.0
@@ -99,7 +59,40 @@ offset_right = -24.0
 offset_bottom = -120.0
 theme_override_styles/panel = SubResource("StyleBoxEmpty_01qpf")
 
+[node name="CenterContent" type="HBoxContainer" parent="PanelOverlay" unique_id=645034186]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 24
+alignment = 1
+
+[node name="OwnerPortrait" type="TextureRect" parent="PanelOverlay/CenterContent" unique_id=665627996]
+custom_minimum_size = Vector2(220, 260)
+layout_mode = 2
+size_flags_horizontal = 0
+size_flags_vertical = 4
+expand_mode = 1
+stretch_mode = 5
+
+[node name="DialoguePanel" type="PanelContainer" parent="PanelOverlay/CenterContent" unique_id=1932082057]
+custom_minimum_size = Vector2(520, 220)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 4
+
+[node name="MarginContainer" type="MarginContainer" parent="PanelOverlay/CenterContent/DialoguePanel" unique_id=215597545]
+layout_mode = 2
+
+[node name="OwnerText" type="RichTextLabel" parent="PanelOverlay/CenterContent/DialoguePanel/MarginContainer" unique_id=1638818097]
+layout_mode = 2
+bbcode_enabled = true
+text = "Welcome."
+fit_content = true
+scroll_active = false
+vertical_alignment = 2
+
 [node name="CloseOverlay" type="Button" parent="." unique_id=1959946455 node_paths=PackedStringArray("CloseTarget")]
+modulate = Color(1, 0.15, 0.15, 1)
 custom_minimum_size = Vector2(56, 56)
 layout_mode = 1
 anchors_preset = 1
@@ -110,10 +103,9 @@ offset_top = 24.0
 offset_right = -24.0
 offset_bottom = 80.0
 grow_horizontal = 0
-modulate = Color(1, 0.15, 0.15, 1)
 theme_override_colors/font_color = Color(1, 1, 1, 1)
-theme_override_colors/font_hover_color = Color(1, 1, 1, 1)
 theme_override_colors/font_pressed_color = Color(1, 1, 1, 1)
+theme_override_colors/font_hover_color = Color(1, 1, 1, 1)
 text = "X"
 script = ExtResource("3_66bgr")
 CloseTarget = NodePath("..")

--- a/scenes/overlays/building/BuildingOverlay.tscn
+++ b/scenes/overlays/building/BuildingOverlay.tscn
@@ -4,6 +4,7 @@
 [ext_resource type="Script" uid="uid://bmqhj3sdl0fnb" path="res://scenes/overlays/building/BuildingOverlay.cs" id="2_qrp73"]
 [ext_resource type="Script" uid="uid://b5nexivgcopri" path="res://core/ui/CloseOverlay.cs" id="3_66bgr"]
 [ext_resource type="PackedScene" uid="uid://cbit1hetoxuyt" path="res://scenes/components/panels/PanelBuilding.tscn" id="4_mlke7"]
+[ext_resource type="PackedScene" uid="uid://b1kf2xl55ull2" path="res://scenes/components/panels/PanelGold.tscn" id="5_gold"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_01qpf"]
 
@@ -47,6 +48,17 @@ offset_left = 24.0
 offset_top = 24.0
 offset_right = 324.0
 offset_bottom = 124.0
+
+[node name="GoldPanel" parent="." unique_id=843888579 instance=ExtResource("5_gold")]
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -264.0
+offset_top = 24.0
+offset_right = -96.0
+offset_bottom = 104.0
+grow_horizontal = 0
 
 [node name="PanelOverlay" type="PanelContainer" parent="." unique_id=642527499]
 layout_mode = 1

--- a/scenes/overlays/building/BuildingOverlayButtonData.cs
+++ b/scenes/overlays/building/BuildingOverlayButtonData.cs
@@ -1,0 +1,10 @@
+using Godot;
+
+[GlobalClass]
+public partial class BuildingOverlayButtonData : Resource {
+	[Export(PropertyHint.File, "*.png,*.svg,*.jpg,*.jpeg,*.webp,*.tres,*.res")]
+	public string IconPath { get; set; }
+
+	[Export] public string LabelName { get; set; }
+	[Export] public PackedScene PathController { get; set; }
+}

--- a/scenes/overlays/building/BuildingOverlayButtonData.cs.uid
+++ b/scenes/overlays/building/BuildingOverlayButtonData.cs.uid
@@ -1,0 +1,1 @@
+uid://enkabhmf46kb

--- a/scenes/overlays/building/SmithOverlay.cs
+++ b/scenes/overlays/building/SmithOverlay.cs
@@ -39,7 +39,7 @@ public partial class SmithOverlay : Control {
 		_currentPage = 0;
 		_selectedItem = null;
 		_items = SaveNode.Get()?.InventoryData?.Items?
-			.Where(item => item != null && item.IsCompatibleWith(MyTypes.OutpostBuildingCompatibility.Smith))
+			.Where(item => item != null && item.HasCompatibility(MyTypes.OutpostBuildingCompatibility.Smith))
 			.ToArray() ?? System.Array.Empty<ItemBase>();
 	}
 
@@ -105,14 +105,14 @@ public partial class SmithOverlay : Control {
 		if (_selectedItem == null) {
 			_previewIcon.Texture = _placeholderIcon;
 			_previewDetails.Text = _items.Length == 0
-				? "No smith-compatible items found."
-				: "Select an item to test smith compatibility.";
+				? "No items are explicitly marked for smith upgrades."
+				: "Select an item that is explicitly marked for smith upgrades.";
 			_selectButton.Disabled = true;
 			return;
 		}
 
 		_previewIcon.Texture = _selectedItem.Icon ?? _placeholderIcon;
-		_previewDetails.Text = $"{_selectedItem.ItemName}\nCompatible with smith. Upgrade logic comes later.";
+		_previewDetails.Text = $"{_selectedItem.ItemName}\nExplicitly marked for smith upgrades. Upgrade logic comes later.";
 		_selectButton.Disabled = false;
 	}
 

--- a/scenes/overlays/building/SmithOverlay.cs
+++ b/scenes/overlays/building/SmithOverlay.cs
@@ -1,0 +1,135 @@
+using Godot;
+using System.Linq;
+
+public partial class SmithOverlay : Control {
+	private const int ItemsPerPage = 8;
+
+	private GridContainer _itemGrid;
+	private Label _emptyLabel;
+	private TextureRect _previewIcon;
+	private Label _previewDetails;
+	private Button _selectButton;
+	private Button _previousPageButton;
+	private Button _nextPageButton;
+	private Label _pageLabel;
+	private readonly PlaceholderTexture2D _placeholderIcon = new() { Size = new Vector2I(64, 64) };
+	private ItemBase[] _items = System.Array.Empty<ItemBase>();
+	private ItemBase _selectedItem;
+	private int _currentPage;
+
+	public override void _Ready() {
+		_itemGrid = GetNode<GridContainer>("Content/ItemPanel/MarginContainer/ItemLayout/ItemGrid");
+		_emptyLabel = GetNode<Label>("Content/ItemPanel/MarginContainer/ItemLayout/EmptyLabel");
+		_previewIcon = GetNode<TextureRect>("Content/PreviewPanel/MarginContainer/PreviewLayout/PreviewIcon");
+		_previewDetails = GetNode<Label>("Content/PreviewPanel/MarginContainer/PreviewLayout/PreviewDetails");
+		_selectButton = GetNode<Button>("Content/PreviewPanel/MarginContainer/PreviewLayout/SelectButton");
+		_previousPageButton = GetNode<Button>("Content/PreviewPanel/MarginContainer/PreviewLayout/PageControls/PreviousPageButton");
+		_nextPageButton = GetNode<Button>("Content/PreviewPanel/MarginContainer/PreviewLayout/PageControls/NextPageButton");
+		_pageLabel = GetNode<Label>("Content/PreviewPanel/MarginContainer/PreviewLayout/PageControls/PageLabel");
+
+		_selectButton.Pressed += OnSelectPressed;
+		_previousPageButton.Pressed += ShowPreviousPage;
+		_nextPageButton.Pressed += ShowNextPage;
+
+		LoadItems();
+		Render();
+	}
+
+	private void LoadItems() {
+		_currentPage = 0;
+		_selectedItem = null;
+		_items = SaveNode.Get()?.InventoryData?.Items?
+			.Where(item => item != null && item.IsCompatibleWith(MyTypes.OutpostBuildingCompatibility.Smith))
+			.ToArray() ?? System.Array.Empty<ItemBase>();
+	}
+
+	private void Render() {
+		RenderItems();
+		RenderPreview();
+	}
+
+	private void RenderItems() {
+		foreach (var child in _itemGrid.GetChildren())
+			child.QueueFree();
+
+		var hasItems = _items.Length > 0;
+		_itemGrid.Visible = hasItems;
+		_emptyLabel.Visible = !hasItems;
+
+		if (!hasItems) {
+			_pageLabel.Visible = false;
+			_previousPageButton.Visible = false;
+			_nextPageButton.Visible = false;
+			return;
+		}
+
+		var pageCount = Mathf.Max(1, Mathf.CeilToInt(_items.Length / (float)ItemsPerPage));
+		_currentPage = Mathf.Clamp(_currentPage, 0, pageCount - 1);
+
+		foreach (var item in _items.Skip(_currentPage * ItemsPerPage).Take(ItemsPerPage)) {
+			_itemGrid.AddChild(CreateItemButton(item));
+		}
+
+		_pageLabel.Visible = true;
+		_previousPageButton.Visible = true;
+		_nextPageButton.Visible = true;
+		_previousPageButton.Disabled = _currentPage <= 0;
+		_nextPageButton.Disabled = _currentPage >= pageCount - 1;
+		_pageLabel.Text = $"Page {_currentPage + 1} / {pageCount}";
+	}
+
+	private Button CreateItemButton(ItemBase item) {
+		var button = new Button {
+			CustomMinimumSize = new Vector2(132, 92),
+			SizeFlagsHorizontal = SizeFlags.ExpandFill,
+			SizeFlagsVertical = SizeFlags.ExpandFill,
+			Text = item.ItemName,
+			Icon = item.Icon ?? _placeholderIcon,
+			IconAlignment = HorizontalAlignment.Center,
+			VerticalIconAlignment = VerticalAlignment.Top,
+			ExpandIcon = true,
+			ClipText = true,
+			AutowrapMode = TextServer.AutowrapMode.WordSmart
+		};
+
+		button.Pressed += () => SelectItem(item);
+		return button;
+	}
+
+	private void SelectItem(ItemBase item) {
+		_selectedItem = item;
+		RenderPreview();
+	}
+
+	private void RenderPreview() {
+		if (_selectedItem == null) {
+			_previewIcon.Texture = _placeholderIcon;
+			_previewDetails.Text = _items.Length == 0
+				? "No smith-compatible items found."
+				: "Select an item to test smith compatibility.";
+			_selectButton.Disabled = true;
+			return;
+		}
+
+		_previewIcon.Texture = _selectedItem.Icon ?? _placeholderIcon;
+		_previewDetails.Text = $"{_selectedItem.ItemName}\nCompatible with smith. Upgrade logic comes later.";
+		_selectButton.Disabled = false;
+	}
+
+	private void OnSelectPressed() {
+		if (_selectedItem == null)
+			return;
+
+		_previewDetails.Text = $"Selected {_selectedItem.ItemName}. Placeholder only.";
+	}
+
+	private void ShowPreviousPage() {
+		_currentPage--;
+		RenderItems();
+	}
+
+	private void ShowNextPage() {
+		_currentPage++;
+		RenderItems();
+	}
+}

--- a/scenes/overlays/building/SmithOverlay.cs.uid
+++ b/scenes/overlays/building/SmithOverlay.cs.uid
@@ -1,0 +1,1 @@
+uid://dqwl71kkbol6m

--- a/scenes/overlays/building/SmithOverlay.tscn
+++ b/scenes/overlays/building/SmithOverlay.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Theme" uid="uid://2us73xfo2hnd" path="res://assets/style/DefaultTheme.tres" id="1_theme"]
 [ext_resource type="Script" path="res://scenes/overlays/building/SmithOverlay.cs" id="2_script"]
 [ext_resource type="Script" uid="uid://b5nexivgcopri" path="res://core/ui/CloseOverlay.cs" id="3_close"]
+[ext_resource type="PackedScene" uid="uid://b1kf2xl55ull2" path="res://scenes/components/panels/PanelGold.tscn" id="4_gold"]
 
 [node name="SmithOverlay" type="Control"]
 layout_mode = 3
@@ -35,6 +36,17 @@ offset_bottom = -32.0
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_constants/separation = 24
+
+[node name="GoldPanel" parent="." unique_id=843888581 instance=ExtResource("4_gold")]
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -264.0
+offset_top = 24.0
+offset_right = -96.0
+offset_bottom = 80.0
+grow_horizontal = 0
 
 [node name="ItemPanel" type="PanelContainer" parent="Content"]
 layout_mode = 2

--- a/scenes/overlays/building/SmithOverlay.tscn
+++ b/scenes/overlays/building/SmithOverlay.tscn
@@ -1,0 +1,157 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Theme" uid="uid://2us73xfo2hnd" path="res://assets/style/DefaultTheme.tres" id="1_theme"]
+[ext_resource type="Script" path="res://scenes/overlays/building/SmithOverlay.cs" id="2_script"]
+[ext_resource type="Script" uid="uid://b5nexivgcopri" path="res://core/ui/CloseOverlay.cs" id="3_close"]
+
+[node name="SmithOverlay" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_theme")
+script = ExtResource("2_script")
+
+[node name="Panel" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.39308554, 0.3930855, 0.39308548, 1)
+
+[node name="Content" type="HBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 32.0
+offset_top = 96.0
+offset_right = -32.0
+offset_bottom = -32.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 24
+
+[node name="ItemPanel" type="PanelContainer" parent="Content"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="MarginContainer" type="MarginContainer" parent="Content/ItemPanel"]
+layout_mode = 2
+theme_override_constants/margin_left = 16
+theme_override_constants/margin_top = 16
+theme_override_constants/margin_right = 16
+theme_override_constants/margin_bottom = 16
+
+[node name="ItemLayout" type="VBoxContainer" parent="Content/ItemPanel/MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 12
+
+[node name="Title" type="Label" parent="Content/ItemPanel/MarginContainer/ItemLayout"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 32
+text = "Smith Items"
+horizontal_alignment = 1
+
+[node name="EmptyLabel" type="Label" parent="Content/ItemPanel/MarginContainer/ItemLayout"]
+layout_mode = 2
+text = "No smith-compatible items found."
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="ItemGrid" type="GridContainer" parent="Content/ItemPanel/MarginContainer/ItemLayout"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+columns = 2
+theme_override_constants/h_separation = 16
+theme_override_constants/v_separation = 16
+
+[node name="PreviewPanel" type="PanelContainer" parent="Content"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="MarginContainer" type="MarginContainer" parent="Content/PreviewPanel"]
+layout_mode = 2
+theme_override_constants/margin_left = 24
+theme_override_constants/margin_top = 24
+theme_override_constants/margin_right = 24
+theme_override_constants/margin_bottom = 24
+
+[node name="PreviewLayout" type="VBoxContainer" parent="Content/PreviewPanel/MarginContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 16
+
+[node name="Title" type="Label" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 36
+text = "Forge"
+
+[node name="PreviewIcon" type="TextureRect" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
+custom_minimum_size = Vector2(128, 128)
+layout_mode = 2
+size_flags_horizontal = 4
+expand_mode = 1
+stretch_mode = 5
+
+[node name="PreviewDetails" type="Label" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
+layout_mode = 2
+size_flags_vertical = 3
+text = "Select an item to test smith compatibility."
+autowrap_mode = 3
+
+[node name="SelectButton" type="Button" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
+custom_minimum_size = Vector2(0, 56)
+layout_mode = 2
+text = "Select"
+
+[node name="PageControls" type="HBoxContainer" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
+layout_mode = 2
+theme_override_constants/separation = 16
+alignment = 1
+
+[node name="PreviousPageButton" type="Button" parent="Content/PreviewPanel/MarginContainer/PreviewLayout/PageControls"]
+custom_minimum_size = Vector2(120, 56)
+layout_mode = 2
+text = "< Prev"
+
+[node name="PageLabel" type="Label" parent="Content/PreviewPanel/MarginContainer/PreviewLayout/PageControls"]
+custom_minimum_size = Vector2(160, 56)
+layout_mode = 2
+text = "Page 1 / 1"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="NextPageButton" type="Button" parent="Content/PreviewPanel/MarginContainer/PreviewLayout/PageControls"]
+custom_minimum_size = Vector2(120, 56)
+layout_mode = 2
+text = "Next >"
+
+[node name="CloseOverlay" type="Button" parent="." node_paths=PackedStringArray("CloseTarget")]
+custom_minimum_size = Vector2(56, 56)
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -80.0
+offset_top = 24.0
+offset_right = -24.0
+offset_bottom = 80.0
+grow_horizontal = 0
+modulate = Color(1, 0.15, 0.15, 1)
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_colors/font_hover_color = Color(1, 1, 1, 1)
+theme_override_colors/font_pressed_color = Color(1, 1, 1, 1)
+text = "X"
+script = ExtResource("3_close")
+CloseTarget = NodePath("..")
+CloseAllOverlayChildren = true
+metadata/_custom_type_script = "uid://b5nexivgcopri"

--- a/scenes/overlays/inventory/InventoryOverlay.cs
+++ b/scenes/overlays/inventory/InventoryOverlay.cs
@@ -118,15 +118,15 @@ public partial class InventoryOverlay : Control {
 			var itemIndex = _currentPage * ItemsPerPage + i;
 			var button = _inventoryButtons[i];
 
-			button.Disabled = false;
-
 			if (itemIndex >= visibleItems.Count) {
 				button.Clear(_placeholderIcon);
-				button.Visible = false;
+				button.Visible = true;
+				button.Disabled = true;
 				continue;
 			}
 
 			button.Visible = true;
+			button.Disabled = false;
 			button.SetItem(visibleItems[itemIndex], _placeholderIcon);
 		}
 
@@ -160,11 +160,6 @@ public partial class InventoryOverlay : Control {
 	}
 
 	private void OnInventoryBoxPressed(ItemInventory button) {
-		if (!button.HasItem) {
-			ShowMessage("Empty inventory box.");
-			return;
-		}
-
 		ShowDetails(button.Item);
 	}
 

--- a/scenes/overlays/inventory/InventoryOverlay.tscn
+++ b/scenes/overlays/inventory/InventoryOverlay.tscn
@@ -46,6 +46,7 @@ theme_override_constants/separation = 16
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
+SkillDescriptionIsClickable = true
 
 [node name="InventoryPanel" type="PanelContainer" parent="Content" unique_id=1811961060]
 layout_mode = 2

--- a/scenes/overlays/inventory/InventoryOverlay.tscn
+++ b/scenes/overlays/inventory/InventoryOverlay.tscn
@@ -231,6 +231,7 @@ alignment = 1
 
 [node name="EquipButton" type="Button" parent="Content/InventoryPanel/MarginContainer/InventoryLayout/Details/ActionButtons" unique_id=1688881871]
 visible = false
+modulate = Color(0.2, 0.75, 0.2, 1)
 custom_minimum_size = Vector2(120, 48)
 layout_mode = 2
 text = "Equip"

--- a/scenes/overlays/main_menu/SettingsOverlay.cs
+++ b/scenes/overlays/main_menu/SettingsOverlay.cs
@@ -1,0 +1,34 @@
+using Godot;
+
+public partial class SettingsOverlay : Control {
+	private Button _soundButton;
+	private Button _videoButton;
+	private Button _dataButton;
+	private Label _categoryTitle;
+	private Control _soundPage;
+	private Control _videoPage;
+	private Control _dataPage;
+
+	public override void _Ready() {
+		_soundButton = GetNode<Button>("Content/CategoryPanel/MarginContainer/CategoryLayout/CategoryButtons/SoundButton");
+		_videoButton = GetNode<Button>("Content/CategoryPanel/MarginContainer/CategoryLayout/CategoryButtons/VideoButton");
+		_dataButton = GetNode<Button>("Content/CategoryPanel/MarginContainer/CategoryLayout/CategoryButtons/DataButton");
+		_categoryTitle = GetNode<Label>("Content/RightPanel/MarginContainer/RightLayout/CategoryTitle");
+		_soundPage = GetNode<Control>("Content/RightPanel/MarginContainer/RightLayout/Pages/SoundPage");
+		_videoPage = GetNode<Control>("Content/RightPanel/MarginContainer/RightLayout/Pages/VideoPage");
+		_dataPage = GetNode<Control>("Content/RightPanel/MarginContainer/RightLayout/Pages/DataPage");
+
+		_soundButton.Pressed += () => SelectPage("Sound");
+		_videoButton.Pressed += () => SelectPage("Video");
+		_dataButton.Pressed += () => SelectPage("Data");
+
+		SelectPage("Sound");
+	}
+
+	private void SelectPage(string pageName) {
+		_categoryTitle.Text = pageName;
+		_soundPage.Visible = pageName == "Sound";
+		_videoPage.Visible = pageName == "Video";
+		_dataPage.Visible = pageName == "Data";
+	}
+}

--- a/scenes/overlays/main_menu/SettingsOverlay.cs.uid
+++ b/scenes/overlays/main_menu/SettingsOverlay.cs.uid
@@ -1,0 +1,1 @@
+uid://dhrcghbba6kxc

--- a/scenes/overlays/main_menu/SettingsOverlay.tscn
+++ b/scenes/overlays/main_menu/SettingsOverlay.tscn
@@ -1,7 +1,11 @@
-[gd_scene load_steps=3 format=3]
+[gd_scene load_steps=7 format=3]
 
 [ext_resource type="Theme" uid="uid://2us73xfo2hnd" path="res://assets/style/DefaultTheme.tres" id="1_settings_theme"]
 [ext_resource type="Script" uid="uid://b5nexivgcopri" path="res://core/ui/CloseOverlay.cs" id="2_settings_close"]
+[ext_resource type="Script" path="res://scenes/overlays/main_menu/SettingsOverlay.cs" id="3_settings_controller"]
+[ext_resource type="PackedScene" path="res://scenes/components/settings/SettingsSoundPage.tscn" id="4_sound_page"]
+[ext_resource type="PackedScene" path="res://scenes/components/settings/SettingsVideoPage.tscn" id="5_video_page"]
+[ext_resource type="PackedScene" path="res://scenes/components/settings/SettingsDataPage.tscn" id="6_data_page"]
 
 [node name="SettingsOverlay" type="Control"]
 layout_mode = 3
@@ -11,6 +15,7 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("1_settings_theme")
+script = ExtResource("3_settings_controller")
 
 [node name="Panel" type="ColorRect" parent="."]
 layout_mode = 1
@@ -20,6 +25,103 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 color = Color(0.39308554, 0.3930855, 0.39308548, 1)
+
+[node name="Content" type="HBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 32.0
+offset_top = 96.0
+offset_right = -32.0
+offset_bottom = -32.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 24
+
+[node name="CategoryPanel" type="PanelContainer" parent="Content"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="MarginContainer" type="MarginContainer" parent="Content/CategoryPanel"]
+layout_mode = 2
+theme_override_constants/margin_left = 16
+theme_override_constants/margin_top = 16
+theme_override_constants/margin_right = 16
+theme_override_constants/margin_bottom = 16
+
+[node name="CategoryLayout" type="VBoxContainer" parent="Content/CategoryPanel/MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 12
+
+[node name="Title" type="Label" parent="Content/CategoryPanel/MarginContainer/CategoryLayout"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 32
+text = "Categories"
+horizontal_alignment = 1
+
+[node name="CategoryButtons" type="VBoxContainer" parent="Content/CategoryPanel/MarginContainer/CategoryLayout"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 8
+
+[node name="SoundButton" type="Button" parent="Content/CategoryPanel/MarginContainer/CategoryLayout/CategoryButtons"]
+custom_minimum_size = Vector2(0, 64)
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Sound"
+
+[node name="VideoButton" type="Button" parent="Content/CategoryPanel/MarginContainer/CategoryLayout/CategoryButtons"]
+custom_minimum_size = Vector2(0, 64)
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Video"
+
+[node name="DataButton" type="Button" parent="Content/CategoryPanel/MarginContainer/CategoryLayout/CategoryButtons"]
+custom_minimum_size = Vector2(0, 64)
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Data"
+
+[node name="RightPanel" type="PanelContainer" parent="Content"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+size_flags_stretch_ratio = 2.0
+
+[node name="MarginContainer" type="MarginContainer" parent="Content/RightPanel"]
+layout_mode = 2
+theme_override_constants/margin_left = 24
+theme_override_constants/margin_top = 24
+theme_override_constants/margin_right = 24
+theme_override_constants/margin_bottom = 24
+
+[node name="RightLayout" type="VBoxContainer" parent="Content/RightPanel/MarginContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 16
+
+[node name="CategoryTitle" type="Label" parent="Content/RightPanel/MarginContainer/RightLayout"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 36
+text = "Sound"
+
+[node name="Pages" type="Control" parent="Content/RightPanel/MarginContainer/RightLayout"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="SoundPage" parent="Content/RightPanel/MarginContainer/RightLayout/Pages" instance=ExtResource("4_sound_page")]
+visible = false
+
+[node name="VideoPage" parent="Content/RightPanel/MarginContainer/RightLayout/Pages" instance=ExtResource("5_video_page")]
+visible = false
+
+[node name="DataPage" parent="Content/RightPanel/MarginContainer/RightLayout/Pages" instance=ExtResource("6_data_page")]
+visible = false
 
 [node name="CloseOverlay" type="Button" parent="." node_paths=PackedStringArray("CloseTarget")]
 custom_minimum_size = Vector2(56, 56)

--- a/scenes/overlays/storefront/StorefrontOverlay.cs
+++ b/scenes/overlays/storefront/StorefrontOverlay.cs
@@ -101,7 +101,7 @@ public partial class StorefrontOverlay : Control {
 
 	private bool CanPurchase(ItemBase item) {
 		var saveNode = SaveNode.Get();
-		return item != null && saveNode?.RunData != null && saveNode.RunData.Gold >= item.Cost;
+		return item != null && saveNode?.RunData != null && saveNode.InventoryData != null && saveNode.RunData.Gold >= item.Cost;
 	}
 
 	private void PurchaseSelectedItem() {
@@ -111,6 +111,9 @@ public partial class StorefrontOverlay : Control {
 		}
 
 		var saveNode = SaveNode.Get();
+		if (saveNode?.InventoryData == null)
+			return;
+
 		saveNode.RunData.Gold -= _selectedItem.Cost;
 		saveNode.InventoryData.AddItem(_selectedItem);
 		_buildingData.StorefrontItems.Remove(_selectedItem);

--- a/scenes/overlays/storefront/StorefrontOverlay.cs
+++ b/scenes/overlays/storefront/StorefrontOverlay.cs
@@ -62,11 +62,12 @@ public partial class StorefrontOverlay : Control {
 	}
 
 	private Button CreateItemButton(ItemBase item) {
+		var itemCount = GetDisplayedItemCount(item);
 		var button = new Button {
 			CustomMinimumSize = new Vector2(132, 92),
 			SizeFlagsHorizontal = SizeFlags.ExpandFill,
 			SizeFlagsVertical = SizeFlags.ExpandFill,
-			Text = item.ItemName,
+			Text = itemCount > 1 ? $"{item.ItemName} x{itemCount}" : item.ItemName,
 			Icon = item.Icon ?? _placeholderIcon,
 			IconAlignment = HorizontalAlignment.Center,
 			VerticalIconAlignment = VerticalAlignment.Top,
@@ -133,6 +134,18 @@ public partial class StorefrontOverlay : Control {
 	}
 
 	private static string FormatItemDetails(ItemBase item) {
-		return $"{item.ItemName}\nStack: {item.MaxStackSize}";
+		var itemCount = GetDisplayedItemCount(item);
+		var countText = itemCount > 1 ? $"\nCount: {itemCount}" : string.Empty;
+		return $"{item.ItemName}\nStack: {item.MaxStackSize}{countText}";
+	}
+
+	private static int GetDisplayedItemCount(ItemBase item) {
+		if (item == null)
+			return 0;
+
+		if (item.IsConsumable && item.UseCountCurrent > 1)
+			return item.UseCountCurrent;
+
+		return item.MaxStackSize;
 	}
 }

--- a/scenes/overlays/storefront/StorefrontOverlay.cs
+++ b/scenes/overlays/storefront/StorefrontOverlay.cs
@@ -1,0 +1,135 @@
+using Godot;
+
+public partial class StorefrontOverlay : Control {
+	private GridContainer _itemGrid;
+	private Label _emptyLabel;
+	private TextureRect _previewIcon;
+	private Label _previewDetails;
+	private Label _priceLabel;
+	private Button _purchaseButton;
+	private readonly PlaceholderTexture2D _placeholderIcon = new() { Size = new Vector2I(64, 64) };
+	private BuildingData _buildingData;
+	private ItemBase _selectedItem;
+
+	public override void _Ready() {
+		_itemGrid = GetNode<GridContainer>("Content/StorePanel/MarginContainer/StoreLayout/ItemGrid");
+		_emptyLabel = GetNode<Label>("Content/StorePanel/MarginContainer/StoreLayout/EmptyLabel");
+		_previewIcon = GetNode<TextureRect>("Content/PreviewPanel/MarginContainer/PreviewLayout/PreviewIcon");
+		_previewDetails = GetNode<Label>("Content/PreviewPanel/MarginContainer/PreviewLayout/PreviewDetails");
+		_priceLabel = GetNode<Label>("Content/PreviewPanel/MarginContainer/PreviewLayout/PriceLabel");
+		_purchaseButton = GetNode<Button>("Content/PreviewPanel/MarginContainer/PreviewLayout/PurchaseButton");
+
+		_purchaseButton.Pressed += PurchaseSelectedItem;
+		SignalHandler.SubscribeGoldAmountChanged(OnGoldAmountChanged);
+		Render();
+	}
+
+	public override void _ExitTree() {
+		SignalHandler.UnsubscribeGoldAmountChanged(OnGoldAmountChanged);
+	}
+
+	public void Update(BuildingData buildingData) {
+		_buildingData = buildingData;
+		_selectedItem = null;
+
+		if (IsNodeReady())
+			Render();
+	}
+
+	private void Render() {
+		RenderItems();
+		RenderPreview();
+	}
+
+	private void RenderItems() {
+		foreach (var child in _itemGrid.GetChildren())
+			child.QueueFree();
+
+		var items = _buildingData?.StorefrontItems;
+		var hasItems = items != null && items.Count > 0;
+		_itemGrid.Visible = hasItems;
+		_emptyLabel.Visible = !hasItems;
+
+		if (!hasItems)
+			return;
+
+		foreach (var item in items) {
+			if (item == null)
+				continue;
+
+			_itemGrid.AddChild(CreateItemButton(item));
+		}
+	}
+
+	private Button CreateItemButton(ItemBase item) {
+		var button = new Button {
+			CustomMinimumSize = new Vector2(132, 92),
+			SizeFlagsHorizontal = SizeFlags.ExpandFill,
+			SizeFlagsVertical = SizeFlags.ExpandFill,
+			Text = item.ItemName,
+			Icon = item.Icon ?? _placeholderIcon,
+			IconAlignment = HorizontalAlignment.Center,
+			VerticalIconAlignment = VerticalAlignment.Top,
+			ExpandIcon = true,
+			ClipText = true,
+			AutowrapMode = TextServer.AutowrapMode.WordSmart
+		};
+
+		button.Pressed += () => SelectItem(item);
+		return button;
+	}
+
+	private void SelectItem(ItemBase item) {
+		_selectedItem = item;
+		RenderPreview();
+	}
+
+	private void RenderPreview() {
+		if (_selectedItem == null) {
+			_previewIcon.Texture = _placeholderIcon;
+			_previewDetails.Text = "Select an item to preview it.";
+			_priceLabel.Text = "Price: -";
+			_purchaseButton.Disabled = true;
+			return;
+		}
+
+		_previewIcon.Texture = _selectedItem.Icon ?? _placeholderIcon;
+		_previewDetails.Text = FormatItemDetails(_selectedItem);
+		_priceLabel.Text = $"Price: {_selectedItem.Cost}";
+		_purchaseButton.Disabled = !CanPurchase(_selectedItem);
+	}
+
+	private bool CanPurchase(ItemBase item) {
+		var saveNode = SaveNode.Get();
+		return item != null && saveNode?.RunData != null && saveNode.RunData.Gold >= item.Cost;
+	}
+
+	private void PurchaseSelectedItem() {
+		if (!CanPurchase(_selectedItem)) {
+			RenderPreview();
+			return;
+		}
+
+		var saveNode = SaveNode.Get();
+		saveNode.RunData.Gold -= _selectedItem.Cost;
+		saveNode.InventoryData.AddItem(_selectedItem);
+		_buildingData.StorefrontItems.Remove(_selectedItem);
+		saveNode.SaveRunData();
+
+		SignalHandler.EmitSignalPurchaseItemStatic(_selectedItem);
+		SignalHandler.EmitSignalGoldAmountChangedStatic(saveNode.RunData.Gold);
+
+		var purchasedItemName = _selectedItem.ItemName;
+		_selectedItem = null;
+		Render();
+		_previewDetails.Text = $"Purchased {purchasedItemName}.";
+	}
+
+	private void OnGoldAmountChanged(int goldAmount) {
+		RenderPreview();
+	}
+
+	private static string FormatItemDetails(ItemBase item) {
+		return $"{item.ItemName}\nStack: {item.MaxStackSize}";
+	}
+}

--- a/scenes/overlays/storefront/StorefrontOverlay.cs.uid
+++ b/scenes/overlays/storefront/StorefrontOverlay.cs.uid
@@ -1,0 +1,1 @@
+uid://c1ljtdokxvm2b

--- a/scenes/overlays/storefront/StorefrontOverlay.tscn
+++ b/scenes/overlays/storefront/StorefrontOverlay.tscn
@@ -1,0 +1,155 @@
+[gd_scene format=3]
+
+[ext_resource type="Theme" uid="uid://2us73xfo2hnd" path="res://assets/style/DefaultTheme.tres" id="1_theme"]
+[ext_resource type="Script" uid="uid://c1ljtdokxvm2b" path="res://scenes/overlays/storefront/StorefrontOverlay.cs" id="2_script"]
+[ext_resource type="Script" uid="uid://b5nexivgcopri" path="res://core/ui/CloseOverlay.cs" id="3_close"]
+
+[sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_preview"]
+size = Vector2(64, 64)
+
+[node name="StorefrontOverlay" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_theme")
+script = ExtResource("2_script")
+
+[node name="Panel" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.393086, 0.393086, 0.393086, 1)
+
+[node name="Content" type="HBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 24.0
+offset_top = 88.0
+offset_right = -24.0
+offset_bottom = -24.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 16
+
+[node name="StorePanel" type="PanelContainer" parent="Content"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+size_flags_stretch_ratio = 2.0
+
+[node name="MarginContainer" type="MarginContainer" parent="Content/StorePanel"]
+layout_mode = 2
+theme_override_constants/margin_left = 12
+theme_override_constants/margin_top = 12
+theme_override_constants/margin_right = 12
+theme_override_constants/margin_bottom = 12
+
+[node name="StoreLayout" type="VBoxContainer" parent="Content/StorePanel/MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 12
+
+[node name="Title" type="Label" parent="Content/StorePanel/MarginContainer/StoreLayout"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 36
+text = "Storefront"
+horizontal_alignment = 1
+
+[node name="ItemGrid" type="GridContainer" parent="Content/StorePanel/MarginContainer/StoreLayout"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/h_separation = 12
+theme_override_constants/v_separation = 12
+columns = 4
+
+[node name="EmptyLabel" type="Label" parent="Content/StorePanel/MarginContainer/StoreLayout"]
+visible = false
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+text = "Nothing is for sale right now."
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="PreviewPanel" type="PanelContainer" parent="Content"]
+custom_minimum_size = Vector2(260, 0)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="MarginContainer" type="MarginContainer" parent="Content/PreviewPanel"]
+layout_mode = 2
+theme_override_constants/margin_left = 12
+theme_override_constants/margin_top = 12
+theme_override_constants/margin_right = 12
+theme_override_constants/margin_bottom = 12
+
+[node name="PreviewLayout" type="VBoxContainer" parent="Content/PreviewPanel/MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 12
+alignment = 1
+
+[node name="PreviewTitle" type="Label" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 28
+text = "Preview"
+horizontal_alignment = 1
+
+[node name="PreviewIcon" type="TextureRect" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
+custom_minimum_size = Vector2(96, 96)
+layout_mode = 2
+size_flags_horizontal = 4
+texture = SubResource("PlaceholderTexture2D_preview")
+expand_mode = 1
+stretch_mode = 5
+
+[node name="PreviewDetails" type="Label" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
+custom_minimum_size = Vector2(0, 96)
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Select an item to preview it."
+horizontal_alignment = 1
+vertical_alignment = 1
+autowrap_mode = 3
+
+[node name="PriceLabel" type="Label" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 24
+text = "Price: -"
+horizontal_alignment = 1
+
+[node name="PurchaseButton" type="Button" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
+custom_minimum_size = Vector2(160, 56)
+layout_mode = 2
+size_flags_horizontal = 4
+disabled = true
+text = "Purchase"
+
+[node name="CloseOverlay" type="Button" parent="." node_paths=PackedStringArray("CloseTarget")]
+modulate = Color(1, 0.15, 0.15, 1)
+custom_minimum_size = Vector2(56, 56)
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -80.0
+offset_top = 24.0
+offset_right = -24.0
+offset_bottom = 80.0
+grow_horizontal = 0
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_colors/font_pressed_color = Color(1, 1, 1, 1)
+theme_override_colors/font_hover_color = Color(1, 1, 1, 1)
+text = "X"
+script = ExtResource("3_close")
+CloseTarget = NodePath("..")
+CloseAllOverlayChildren = true
+metadata/_custom_type_script = "uid://b5nexivgcopri"

--- a/scenes/overlays/storefront/StorefrontOverlay.tscn
+++ b/scenes/overlays/storefront/StorefrontOverlay.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Theme" uid="uid://2us73xfo2hnd" path="res://assets/style/DefaultTheme.tres" id="1_theme"]
 [ext_resource type="Script" uid="uid://c1ljtdokxvm2b" path="res://scenes/overlays/storefront/StorefrontOverlay.cs" id="2_script"]
 [ext_resource type="Script" uid="uid://b5nexivgcopri" path="res://core/ui/CloseOverlay.cs" id="3_close"]
+[ext_resource type="PackedScene" uid="uid://b1kf2xl55ull2" path="res://scenes/components/panels/PanelGold.tscn" id="4_gold"]
 
 [sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_preview"]
 size = Vector2(64, 64)
@@ -38,6 +39,17 @@ offset_bottom = -24.0
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_constants/separation = 16
+
+[node name="GoldPanel" parent="." unique_id=843888580 instance=ExtResource("4_gold")]
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -264.0
+offset_top = 24.0
+offset_right = -96.0
+offset_bottom = 80.0
+grow_horizontal = 0
 
 [node name="StorePanel" type="PanelContainer" parent="Content"]
 layout_mode = 2

--- a/scenes/startmenu/gem.tscn
+++ b/scenes/startmenu/gem.tscn
@@ -13,7 +13,7 @@ offset_right = -1024.0
 offset_bottom = -520.0
 grow_horizontal = 2
 grow_vertical = 2
-mouse_filter = 2
+mouse_filter = 1
 script = ExtResource("1_r6t6j")
 
 [node name="Background" type="TextureRect" parent="." unique_id=22563225]


### PR DESCRIPTION
## Summary
- add reusable outpost building overlays, storefront data flow, and smith compatibility plumbing for item interactions
- persist outpost and settings data while improving related UI flows, blur popups, and inventory/equipment presentation for user testing
- tighten smith overlay filtering so only items explicitly marked for smith upgrades appear in the forge