### PR TITLE
add contract path selection and desktop onboarding notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,25 @@ Start -> Choose Path -> Fight -> Upgrade -> Boss -> Reward -> Repeat
 
 <img width="800" alt="Game loop diagram" src="docs/images/game-loop-diagram.png" />
 
+## Graphic Style (Decision Pending)
+
+The project is currently evaluating two art pipelines:
+
+### Option A — Pixel Art (preferred direction)
+- Top-down 2D pixel art
+- Strong readability and silhouette clarity
+- Supports fast iteration and content-heavy design
+- Fits procedural character system and equipment layering
+
+### Option B — SVG / Vector
+- Resolution-independent assets
+- Cleaner UI integration
+- Easier scaling across devices
+- Requires additional work for depth, lighting, and game feel
+
+Final decision will be locked before full asset production begins.
+
+**Rule:** Do not mix pipelines.
 ## Visual References
 
 <details open>

--- a/assets/shaders/PopupBlurBackdrop.gdshader.uid
+++ b/assets/shaders/PopupBlurBackdrop.gdshader.uid
@@ -1,0 +1,1 @@
+uid://bpbpvqt0mqen3

--- a/autoload/overlay/GlobalOverlay.cs
+++ b/autoload/overlay/GlobalOverlay.cs
@@ -56,6 +56,13 @@ public partial class GlobalOverlay : CanvasLayer {
 		_activeInfoPopup.Closed += OnInfoPopupClosed;
 	}
 
+	public void ShowDesktopGameplayNotice() {
+		ShowBlurredPopup(
+			"Mobile-first gameplay",
+			"This game is mainly built for phone gameplay. It still runs on desktop, but the controls and interface are designed around touch and portrait-style play."
+		);
+	}
+
 	public void CloseTopOverlay() {
 		if (GodotObject.IsInstanceValid(_activeInfoPopup)) {
 			CloseInfoPopup();

--- a/autoload/save/SaveNode.cs
+++ b/autoload/save/SaveNode.cs
@@ -182,13 +182,16 @@ public partial class SaveNode : Node {
 			return;
 		}
 
-		GD.Print($"CompleteContract: moving to {contract.Biome} / {contract.EndLocation}.");
+		var previousBiome = RunData.CurrentBiome;
+		GD.Print($"CompleteContract: moving to {contract.Biome}.");
 		RunData.CurrentBiome = contract.Biome;
-		RunData.CurrentLocation = contract.EndLocation;
 		RunData.ContractsCompleted++;
+		RunData.CurrentBiomeContractsCompleted = previousBiome == contract.Biome
+			? RunData.CurrentBiomeContractsCompleted + 1
+			: 0;
 		RunData.CurrentContract = null;
 		RunData.OutpostData = null;
-		GD.Print($"CompleteContract: contracts completed is now {RunData.ContractsCompleted}. Outpost buildings cleared.");
+		GD.Print($"CompleteContract: contracts completed is now {RunData.ContractsCompleted}, current biome contracts completed is {RunData.CurrentBiomeContractsCompleted}. Outpost buildings cleared.");
 		SaveRunData();
 	}
 

--- a/autoload/save/data/ContractChooseData.cs
+++ b/autoload/save/data/ContractChooseData.cs
@@ -1,0 +1,121 @@
+using Godot;
+using Godot.Collections;
+using MyTypes;
+
+namespace SaveData {
+	[GlobalClass]
+	public partial class ContractChooseData : SaveResource {
+		private const int GeneratedContractCount = 3;
+		private static readonly Biomes[] GrasslandsChoices = { Biomes.GrasslandsA };
+		private static readonly Biomes[] GrasslandsProgressionChoices = { Biomes.GrasslandsA, Biomes.TundraB, Biomes.DesertB };
+		private static readonly Biomes[] TundraBranchChoices = { Biomes.TundraB, Biomes.IcyC, Biomes.JungleC };
+		private static readonly Biomes[] DesertBranchChoices = { Biomes.DesertB, Biomes.JungleC, Biomes.LavaC };
+		private static readonly Biomes[] IcyBossChoice = { Biomes.IcyC, Biomes.IceBossD };
+		private static readonly Biomes[] JungleBossChoice = { Biomes.JungleC, Biomes.JungleBossD };
+		private static readonly Biomes[] LavaBossChoice = { Biomes.LavaC, Biomes.LavaBossD };
+		private static readonly Biomes[] FallbackChoices = { Biomes.GrasslandsA };
+
+		[Export] public Array<Contract> Contracts { get; set; } = new();
+
+		public Contract CreateRandomContract(Biomes currentBiome, int currentBiomeContractsCompleted, RandomNumberGenerator random = null) {
+			random ??= new RandomNumberGenerator();
+			random.Randomize();
+
+			var availableBiomes = GetAvailableBiomes(currentBiome, currentBiomeContractsCompleted);
+			var biome = GetWeightedRandomBiome(currentBiome, currentBiomeContractsCompleted, availableBiomes, random);
+
+			return new Contract {
+				Biome = biome
+			};
+		}
+
+		public void GenerateContracts(Biomes currentBiome, int currentBiomeContractsCompleted) {
+			Contracts.Clear();
+			var random = new RandomNumberGenerator();
+			random.Randomize();
+			var allowDuplicates = GetAvailableContractVariantCount(currentBiome, currentBiomeContractsCompleted) < GeneratedContractCount;
+
+			while (Contracts.Count < GeneratedContractCount) {
+				var contract = CreateRandomContract(currentBiome, currentBiomeContractsCompleted, random);
+				if (!allowDuplicates && ContainsContract(contract))
+					continue;
+
+				Contracts.Add(contract);
+			}
+		}
+
+		private bool ContainsContract(Contract candidate) {
+			foreach (var contract in Contracts) {
+				if (contract == null)
+					continue;
+
+				if (contract.Biome == candidate.Biome)
+					return true;
+			}
+
+			return false;
+		}
+
+		private static Biomes[] GetAvailableBiomes(Biomes currentBiome, int currentBiomeContractsCompleted) {
+			if (currentBiome == Biomes.GrasslandsA && currentBiomeContractsCompleted <= 0)
+				return GrasslandsChoices;
+
+			return currentBiome switch {
+				Biomes.GrasslandsA => GrasslandsProgressionChoices,
+				Biomes.TundraB => TundraBranchChoices,
+				Biomes.DesertB => DesertBranchChoices,
+				Biomes.IcyC => IcyBossChoice,
+				Biomes.JungleC => JungleBossChoice,
+				Biomes.LavaC => LavaBossChoice,
+				_ => FallbackChoices
+			};
+		}
+
+		private static Biomes GetWeightedRandomBiome(Biomes currentBiome, int currentBiomeContractsCompleted, Biomes[] availableBiomes, RandomNumberGenerator random) {
+			if (availableBiomes == null || availableBiomes.Length == 0)
+				return Biomes.GrasslandsA;
+
+			if (availableBiomes.Length == 1)
+				return availableBiomes[0];
+
+			var nextBiomeChance = GetNextBiomeChance(currentBiome, currentBiomeContractsCompleted);
+			if (random.Randf() >= nextBiomeChance)
+				return availableBiomes[0];
+
+			if (availableBiomes.Length == 2)
+				return availableBiomes[1];
+
+			return random.Randf() < 0.6f ? availableBiomes[1] : availableBiomes[2];
+		}
+
+		private static int GetAvailableContractVariantCount(Biomes currentBiome, int currentBiomeContractsCompleted) {
+			var biomes = GetAvailableBiomes(currentBiome, currentBiomeContractsCompleted);
+			return biomes.Length;
+		}
+
+		private static float GetNextBiomeChance(Biomes currentBiome, int currentBiomeContractsCompleted) {
+			return currentBiome switch {
+				Biomes.GrasslandsA => Mathf.Clamp(0.15f + (currentBiomeContractsCompleted * 0.2f), 0.15f, 0.9f),
+				Biomes.TundraB or Biomes.DesertB => Mathf.Clamp(0.2f + (currentBiomeContractsCompleted * 0.18f), 0.2f, 0.9f),
+				Biomes.IcyC or Biomes.JungleC or Biomes.LavaC => Mathf.Clamp(0.35f + (currentBiomeContractsCompleted * 0.25f), 0.35f, 1.0f),
+				_ => 1.0f
+			};
+		}
+
+		public override string ToString() {
+			if (Contracts == null || Contracts.Count == 0)
+				return "[]";
+
+			var result = "[";
+			for (var i = 0; i < Contracts.Count; i++) {
+				if (i > 0)
+					result += ", ";
+
+				var contract = Contracts[i];
+				result += contract == null ? "None" : contract.Biome.ToString();
+			}
+
+			return result + "]";
+		}
+	}
+}

--- a/autoload/save/data/ContractChooseData.cs.uid
+++ b/autoload/save/data/ContractChooseData.cs.uid
@@ -1,0 +1,1 @@
+uid://135ryjquf1q

--- a/autoload/save/data/OutpostData.cs
+++ b/autoload/save/data/OutpostData.cs
@@ -2,16 +2,17 @@ using Godot;
 using Godot.Collections;
 
 
-namespace SaveData {
-	[GlobalClass]
-	public partial class OutpostData : SaveResource {
-		[Export] public Array<BuildingData> Buildings { get; set; }
+	namespace SaveData {
+		[GlobalClass]
+		public partial class OutpostData : SaveResource {
+			[Export] public Array<BuildingData> Buildings { get; set; }
+			[Export] public ContractChooseData ContractChooseData { get; set; }
 
-		public override string ToString() {
-			return $"OutpostData:\n  Buildings={FormatBuildings(Buildings)}";
-		}
+			public override string ToString() {
+				return $"OutpostData:\n  Buildings={FormatBuildings(Buildings)}\n  ContractChooseData={ContractChooseData?.ToString() ?? "None"}";
+			}
 
-		private static string FormatBuildings(Array<BuildingData> buildings) {
+			private static string FormatBuildings(Array<BuildingData> buildings) {
 			if (buildings == null || buildings.Count == 0)
 				return "[]";
 

--- a/autoload/save/data/RunData.cs
+++ b/autoload/save/data/RunData.cs
@@ -11,6 +11,7 @@ namespace SaveData {
 		[Export] public Contract CurrentContract { get; set; } = null;
 		[Export] public OutpostData OutpostData { get; set; }
 		[Export] public int ContractsCompleted { get; set; } = 0;
+		[Export] public int CurrentBiomeContractsCompleted { get; set; } = 0;
 		[Export] public int Gold { get; set; } = 100;
 		public override string ToString() {
 			return $"RunData:\n"
@@ -20,6 +21,7 @@ namespace SaveData {
 				+ $"  CurrentContract={FormatResource(CurrentContract)}\n"
 				+ $"  OutpostData={FormatResource(OutpostData)}\n"
 				+ $"  ContractsCompleted={ContractsCompleted}\n"
+				+ $"  CurrentBiomeContractsCompleted={CurrentBiomeContractsCompleted}\n"
 				+ $"  Gold={Gold}";
 		}
 

--- a/core/items/ItemBase.cs
+++ b/core/items/ItemBase.cs
@@ -12,7 +12,7 @@ public partial class ItemBase : Resource {
 	[Export] public int MaxStackSize { get; set; } = 1;
 	[Export] public int Cost { get; set; } = 0;
 	[Export] public string ItemID { get; set; }
-	[Export] public ItemOutpostCompatibilityData OutpostCompatibility { get; set; }
+	[Export] public ItemOutpostCompatibilityData? OutpostCompatibility { get; set; }
 	[Export] public bool IsConsumable { get; set; } = false;
 	[Export] public int UseCountMax { get; set; } = 0;
 	[Export] public int UseCountDefault { get; set; } = 0;

--- a/core/progression/Contract.cs
+++ b/core/progression/Contract.cs
@@ -4,5 +4,4 @@ using MyTypes;
 [GlobalClass]
 public partial class Contract : Resource {
 	[Export] public Biomes Biome { get; set; }
-	[Export] public Locations EndLocation { get; set; }
 }

--- a/scenes/components/character/NewCharacterComponent.tscn
+++ b/scenes/components/character/NewCharacterComponent.tscn
@@ -56,7 +56,7 @@ grow_horizontal = 2
 grow_vertical = 2
 theme_override_constants/separation = 18
 
-[node name="PlayerPreview" type="VBoxContainer" parent="TopUi"]
+[node name="PlayerPreview" type="VBoxContainer" parent="TopUi" unique_id=1854498198]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -79,14 +79,14 @@ text = "$Character Name"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="StartingItem" type="VBoxContainer" parent="TopUi"]
+[node name="StartingItem" type="VBoxContainer" parent="TopUi" unique_id=1440471943]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_constants/separation = 6
 alignment = 1
 
-[node name="TitleLabel" type="Label" parent="TopUi/StartingItem"]
+[node name="TitleLabel" type="Label" parent="TopUi/StartingItem" unique_id=794846194]
 custom_minimum_size = Vector2(0, 28)
 layout_mode = 2
 size_flags_horizontal = 3
@@ -94,7 +94,7 @@ text = "Starting Item"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="ItemIcon" type="TextureRect" parent="TopUi/StartingItem"]
+[node name="ItemIcon" type="TextureRect" parent="TopUi/StartingItem" unique_id=2019402820]
 custom_minimum_size = Vector2(72, 72)
 layout_mode = 2
 size_flags_horizontal = 4
@@ -102,7 +102,7 @@ size_flags_vertical = 3
 texture = SubResource("PlaceholderTexture2D_ga2uj")
 stretch_mode = 5
 
-[node name="ItemNameLabel" type="Label" parent="TopUi/StartingItem"]
+[node name="ItemNameLabel" type="Label" parent="TopUi/StartingItem" unique_id=1436200213]
 custom_minimum_size = Vector2(0, 36)
 layout_mode = 2
 size_flags_horizontal = 3

--- a/scenes/components/equipment/EquipmentPanel.cs
+++ b/scenes/components/equipment/EquipmentPanel.cs
@@ -6,10 +6,17 @@ public partial class EquipmentPanel : PanelContainer {
 
 	private bool _enableButtonPresses = true;
 	private bool _skillDescriptionIsClickable;
+	private bool _disableEmptySlotPresses;
+	private bool _hideEmptySlotIcons;
 	private bool _useSaveNodeData = true;
 	private EquipedItemsData _equipedItems;
 	private PanelStats _panelStats;
 
+	/// <summary>
+	/// Enables slot button interaction for this panel instance.
+	/// Set this to <c>false</c> in read-only views that should only display equipment,
+	/// such as run previews, so pressing equipment slots does nothing.
+	/// </summary>
 	[Export]
 	public bool EnableButtonPresses {
 		get => _enableButtonPresses;
@@ -19,6 +26,11 @@ public partial class EquipmentPanel : PanelContainer {
 		}
 	}
 
+	/// <summary>
+	/// Enables the embedded stat rows to open the shared blurred info popup when clicked.
+	/// Set this to <c>true</c> in scenes where the stat labels should act as help buttons,
+	/// and leave it <c>false</c> in passive displays.
+	/// </summary>
 	[Export]
 	public bool SkillDescriptionIsClickable {
 		get => _skillDescriptionIsClickable;
@@ -28,6 +40,38 @@ public partial class EquipmentPanel : PanelContainer {
 		}
 	}
 
+	/// <summary>
+	/// Disables only the equipment slot buttons that do not currently contain an item.
+	/// Use this in views like the inventory overlay where empty slots should stay visible
+	/// but should not be pressable.
+	/// </summary>
+	[Export]
+	public bool DisableEmptySlotPresses {
+		get => _disableEmptySlotPresses;
+		set {
+			_disableEmptySlotPresses = value;
+			ApplyInteractionState();
+		}
+	}
+
+	/// <summary>
+	/// Hides the placeholder icon for empty equipment slots while keeping icons for equipped items.
+	/// Use this when a scene should show only real equipped item art and leave empty slots visually blank.
+	/// </summary>
+	[Export]
+	public bool HideEmptySlotIcons {
+		get => _hideEmptySlotIcons;
+		set {
+			_hideEmptySlotIcons = value;
+			Render();
+		}
+	}
+
+	/// <summary>
+	/// Chooses whether this panel reads equipped items from the global save data or from the exported
+	/// <see cref="EquipedItems"/> value below. Keep this enabled for the live player inventory/equipment view,
+	/// and disable it for preview scenes that inject their own equipment data.
+	/// </summary>
 	[Export]
 	public bool UseSaveNodeData {
 		get => _useSaveNodeData;
@@ -37,6 +81,10 @@ public partial class EquipmentPanel : PanelContainer {
 		}
 	}
 
+	/// <summary>
+	/// Provides explicit equipment data for this panel instance when <see cref="UseSaveNodeData"/> is disabled.
+	/// This is intended for reusable preview screens that should not read from the player's active save.
+	/// </summary>
 	[Export]
 	public EquipedItemsData EquipedItems {
 		get => _equipedItems;
@@ -91,6 +139,7 @@ public partial class EquipmentPanel : PanelContainer {
 			var text = item?.ItemName ?? "Empty";
 			_equipmentButtons[i].Text = $"{slotName}\n{text}";
 			_equipmentButtons[i].Icon = GetItemIcon(item);
+			_equipmentButtons[i].Disabled = DisableEmptySlotPresses && item == null;
 		}
 	}
 
@@ -131,6 +180,9 @@ public partial class EquipmentPanel : PanelContainer {
 	}
 
 	private Texture2D GetItemIcon(ItemBase item) {
+		if (item == null && HideEmptySlotIcons)
+			return null;
+
 		if (item is ItemEquipable equipable && equipable.EquippedTexture != null) {
 			return equipable.EquippedTexture;
 		}

--- a/scenes/components/outpost/contract_building_data.tres
+++ b/scenes/components/outpost/contract_building_data.tres
@@ -11,7 +11,7 @@ PathController = ExtResource("2_contract_select")
 
 [resource]
 script = ExtResource("1_contract")
-LabelName = "Contract"
-Description = "Choose the next contract for this run."
-OwnerText = "Contracts are waiting. Pick carefully; the outpost only pays for work that gets finished."
+LabelName = "Path"
+Description = "Choose the next path for this run."
+OwnerText = "Paths are opening. Pick carefully; each choice shapes where this run goes next."
 OverlayButtons = Array[Resource]([SubResource("Resource_choose_contract")])

--- a/scenes/components/outpost/contract_building_data.tres
+++ b/scenes/components/outpost/contract_building_data.tres
@@ -1,10 +1,17 @@
-[gd_resource type="Resource" script_class="BuildingData" format=3 uid="uid://dc5yw0wdd4tyc"]
+[gd_resource type="Resource" script_class="BuildingData" load_steps=3 format=3 uid="uid://dc5yw0wdd4tyc"]
 
 [ext_resource type="Script" uid="uid://enkabhmf46kb" path="res://scenes/overlays/building/BuildingOverlayButtonData.cs" id="1_2fvkw"]
 [ext_resource type="Script" uid="uid://cd5blmxgvl3oe" path="res://scenes/components/outpost/BuildingData.cs" id="1_contract"]
+[ext_resource type="PackedScene" path="res://scenes/overlays/outpost/ContractSelectOverlay.tscn" id="2_contract_select"]
+
+[sub_resource type="Resource" id="Resource_choose_contract"]
+script = ExtResource("1_2fvkw")
+LabelName = "Choose Path"
+PathController = ExtResource("2_contract_select")
 
 [resource]
 script = ExtResource("1_contract")
 LabelName = "Contract"
 Description = "Choose the next contract for this run."
 OwnerText = "Contracts are waiting. Pick carefully; the outpost only pays for work that gets finished."
+OverlayButtons = Array[Resource]([SubResource("Resource_choose_contract")])

--- a/scenes/components/panels/InfoPopupPanel.cs.uid
+++ b/scenes/components/panels/InfoPopupPanel.cs.uid
@@ -1,0 +1,1 @@
+uid://0dsvsun70ui

--- a/scenes/components/panels/PanelRunMetadata.cs
+++ b/scenes/components/panels/PanelRunMetadata.cs
@@ -40,7 +40,7 @@ public partial class PanelRunMetadata : Control {
 		if (contract == null)
 			return "None";
 
-		return $"{FormatBiomeName(contract.Biome.ToString())} -> {FormatEnumName(contract.EndLocation.ToString())}";
+		return FormatBiomeName(contract.Biome.ToString());
 	}
 
 	private static string FormatBiomeName(RunData runData) {

--- a/scenes/components/panels/PanelRunMetadata.tscn
+++ b/scenes/components/panels/PanelRunMetadata.tscn
@@ -191,7 +191,7 @@ theme_override_constants/separation = 2
 
 [node name="Name" type="Label" parent="Content/Rows/CurrentContractRow/MarginContainer/Entry"]
 layout_mode = 2
-text = "Current Contract"
+text = "Current Path"
 clip_text = true
 
 [node name="Value" type="Label" parent="Content/Rows/CurrentContractRow/MarginContainer/Entry"]

--- a/scenes/components/stats/PanelStats.tscn
+++ b/scenes/components/stats/PanelStats.tscn
@@ -38,10 +38,9 @@ stretch_mode = 5
 [node name="LabelName" type="Label" parent="StatStr" unique_id=1840103329]
 layout_mode = 1
 anchors_preset = -1
-anchor_left = 0.083000004
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 0.38399506
+offset_left = 52.0
 offset_right = -96.0
 grow_horizontal = 2
 grow_vertical = 2
@@ -85,10 +84,9 @@ stretch_mode = 5
 [node name="LabelName" type="Label" parent="StatAgi" unique_id=735923346]
 layout_mode = 1
 anchors_preset = -1
-anchor_left = 0.083000004
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 0.38399506
+offset_left = 52.0
 offset_right = -96.0
 grow_horizontal = 2
 grow_vertical = 2
@@ -132,10 +130,9 @@ stretch_mode = 5
 [node name="LabelName" type="Label" parent="StatArc" unique_id=1364201953]
 layout_mode = 1
 anchors_preset = -1
-anchor_left = 0.083000004
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 0.38399506
+offset_left = 52.0
 offset_right = -96.0
 grow_horizontal = 2
 grow_vertical = 2
@@ -179,10 +176,9 @@ stretch_mode = 5
 [node name="LabelName" type="Label" parent="StatVit" unique_id=1885446992]
 layout_mode = 1
 anchors_preset = -1
-anchor_left = 0.083000004
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 0.38399506
+offset_left = 52.0
 offset_right = -96.0
 grow_horizontal = 2
 grow_vertical = 2

--- a/scenes/main/main_menu/StartMenu.cs
+++ b/scenes/main/main_menu/StartMenu.cs
@@ -1,8 +1,24 @@
 using Godot;
 
 public partial class StartMenu : Control {
+	public override void _Ready() {
+		ShowDesktopGameplayNoticeIfNeeded();
+	}
+
 	public override void _Notification(int what) {
 		if (what == NotificationWMGoBackRequest)
 			GetTree().Quit();
+	}
+
+	private void ShowDesktopGameplayNoticeIfNeeded() {
+		var showTips = SaveNode.Get().SettingsData?.EnableFirstRunTips ?? true;
+		if (!showTips || OS.HasFeature("mobile"))
+			return;
+
+		CallDeferred(MethodName.ShowDesktopGameplayNotice);
+	}
+
+	private void ShowDesktopGameplayNotice() {
+		GlobalOverlay.Get()?.ShowDesktopGameplayNotice();
 	}
 }

--- a/scenes/main/outpost/Outpost.cs.uid
+++ b/scenes/main/outpost/Outpost.cs.uid
@@ -1,0 +1,1 @@
+uid://cj2vm2cq6edcv

--- a/scenes/main/outpost/OutpostBuildings.cs
+++ b/scenes/main/outpost/OutpostBuildings.cs
@@ -23,7 +23,8 @@ public partial class OutpostBuildings : Node2D {
 		if (buildings == null || buildings.Count != GetChildCount()) {
 			buildings = GenerateOutpostBuildings();
 			saveNode.RunData.OutpostData = new OutpostData {
-				Buildings = buildings
+				Buildings = buildings,
+				ContractChooseData = new ContractChooseData()
 			};
 			saveNode.SaveRunData();
 		}

--- a/scenes/overlays/inventory/InventoryOverlay.cs
+++ b/scenes/overlays/inventory/InventoryOverlay.cs
@@ -120,7 +120,7 @@ public partial class InventoryOverlay : Control {
 
 			if (itemIndex >= visibleItems.Count) {
 				button.Clear(_placeholderIcon);
-				button.Visible = true;
+				button.Visible = false;
 				button.Disabled = true;
 				continue;
 			}

--- a/scenes/overlays/inventory/InventoryOverlay.tscn
+++ b/scenes/overlays/inventory/InventoryOverlay.tscn
@@ -47,6 +47,8 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 SkillDescriptionIsClickable = true
+DisableEmptySlotPresses = true
+HideEmptySlotIcons = true
 
 [node name="InventoryPanel" type="PanelContainer" parent="Content" unique_id=1811961060]
 layout_mode = 2

--- a/scenes/overlays/outpost/ContractSelectOverlay.cs
+++ b/scenes/overlays/outpost/ContractSelectOverlay.cs
@@ -86,14 +86,14 @@ public partial class ContractSelectOverlay : Control {
 
 	private void RenderPreview() {
 		if (_selectedContract == null) {
-			_selectedTitle.Text = "Choose Contract";
-			_selectedDetails.Text = "Select one of the available contracts to continue the run.";
+			_selectedTitle.Text = "Choose Path";
+			_selectedDetails.Text = "Select one of the available paths to continue the run.";
 			_chooseButton.Disabled = true;
 			return;
 		}
 
 		_selectedTitle.Text = FormatContractTitle(_selectedContract);
-		_selectedDetails.Text = $"Biome: {FormatBiomeName(_selectedContract.Biome)}\n\nAccepting this contract will set the next path for the current run.";
+		_selectedDetails.Text = $"Biome: {FormatBiomeName(_selectedContract.Biome)}\n\nAccepting this path will set the next path for the current run.";
 		_chooseButton.Disabled = false;
 	}
 

--- a/scenes/overlays/outpost/ContractSelectOverlay.cs
+++ b/scenes/overlays/outpost/ContractSelectOverlay.cs
@@ -1,0 +1,142 @@
+using Godot;
+using SaveData;
+
+public partial class ContractSelectOverlay : Control {
+	private VBoxContainer _contractList;
+	private Label _emptyLabel;
+	private Label _selectedTitle;
+	private Label _selectedDetails;
+	private Button _chooseButton;
+	private readonly PlaceholderTexture2D _placeholderIcon = new() { Size = new Vector2I(64, 64) };
+	private ContractChooseData _contractChooseData;
+	private Contract _selectedContract;
+
+	public override void _Ready() {
+		_contractList = GetNode<VBoxContainer>("Content/ContractPanel/MarginContainer/ContractLayout/ContractList");
+		_emptyLabel = GetNode<Label>("Content/ContractPanel/MarginContainer/ContractLayout/EmptyLabel");
+		_selectedTitle = GetNode<Label>("Content/PreviewPanel/MarginContainer/PreviewLayout/Title");
+		_selectedDetails = GetNode<Label>("Content/PreviewPanel/MarginContainer/PreviewLayout/PreviewDetails");
+		_chooseButton = GetNode<Button>("Content/PreviewPanel/MarginContainer/PreviewLayout/ChooseButton");
+
+		_chooseButton.Pressed += OnChoosePressed;
+		LoadContracts();
+		Render();
+	}
+
+	private void LoadContracts() {
+		var saveNode = SaveNode.Get();
+		if (saveNode?.RunData == null)
+			return;
+
+		saveNode.RunData.OutpostData ??= new OutpostData();
+		saveNode.RunData.OutpostData.ContractChooseData ??= new ContractChooseData();
+		_contractChooseData = saveNode.RunData.OutpostData.ContractChooseData;
+
+		if (_contractChooseData.Contracts == null || _contractChooseData.Contracts.Count != 3) {
+			_contractChooseData.GenerateContracts(saveNode.RunData.CurrentBiome, saveNode.RunData.CurrentBiomeContractsCompleted);
+			saveNode.SaveRunData();
+		}
+	}
+
+	private void Render() {
+		RenderContracts();
+		RenderPreview();
+	}
+
+	private void RenderContracts() {
+		foreach (var child in _contractList.GetChildren())
+			child.QueueFree();
+
+		var contracts = _contractChooseData?.Contracts;
+		var hasContracts = contracts != null && contracts.Count > 0;
+		_contractList.Visible = hasContracts;
+		_emptyLabel.Visible = !hasContracts;
+
+		if (!hasContracts)
+			return;
+
+		foreach (var contract in contracts) {
+			if (contract == null)
+				continue;
+
+			_contractList.AddChild(CreateContractButton(contract));
+		}
+
+		_selectedContract ??= contracts[0];
+	}
+
+	private Button CreateContractButton(Contract contract) {
+		var button = new Button {
+			CustomMinimumSize = new Vector2(0, 84),
+			SizeFlagsHorizontal = SizeFlags.ExpandFill,
+			Text = FormatContractTitle(contract),
+			Icon = _placeholderIcon,
+			TextOverrunBehavior = TextServer.OverrunBehavior.TrimEllipsis,
+			Alignment = HorizontalAlignment.Left
+		};
+
+		button.Pressed += () => SelectContract(contract);
+		return button;
+	}
+
+	private void SelectContract(Contract contract) {
+		_selectedContract = contract;
+		RenderPreview();
+	}
+
+	private void RenderPreview() {
+		if (_selectedContract == null) {
+			_selectedTitle.Text = "Choose Contract";
+			_selectedDetails.Text = "Select one of the available contracts to continue the run.";
+			_chooseButton.Disabled = true;
+			return;
+		}
+
+		_selectedTitle.Text = FormatContractTitle(_selectedContract);
+		_selectedDetails.Text = $"Biome: {FormatBiomeName(_selectedContract.Biome)}\n\nAccepting this contract will set the next path for the current run.";
+		_chooseButton.Disabled = false;
+	}
+
+	private void OnChoosePressed() {
+		if (_selectedContract == null)
+			return;
+
+		var saveNode = SaveNode.Get();
+		if (saveNode?.RunData == null)
+			return;
+
+		saveNode.RunData.CurrentContract = _selectedContract;
+		if (saveNode.RunData.OutpostData?.ContractChooseData != null)
+			saveNode.RunData.OutpostData.ContractChooseData.Contracts.Clear();
+
+		saveNode.SaveRunData();
+		QueueFree();
+	}
+
+	private static string FormatContractTitle(Contract contract) {
+		return FormatBiomeName(contract.Biome);
+	}
+
+	private static string FormatBiomeName(MyTypes.Biomes biome) {
+		var biomeName = biome.ToString();
+		if (biomeName.Length > 1 && char.IsLetter(biomeName[^1]) && char.IsUpper(biomeName[^1]))
+			biomeName = biomeName[..^1];
+
+		return FormatEnumName(biomeName);
+	}
+
+	private static string FormatEnumName(string value) {
+		if (string.IsNullOrWhiteSpace(value))
+			return "Unknown";
+
+		var result = value[0].ToString();
+		for (var i = 1; i < value.Length; i++) {
+			if (char.IsUpper(value[i]) && !char.IsWhiteSpace(value[i - 1]))
+				result += " ";
+
+			result += value[i];
+		}
+
+		return result;
+	}
+}

--- a/scenes/overlays/outpost/ContractSelectOverlay.cs.uid
+++ b/scenes/overlays/outpost/ContractSelectOverlay.cs.uid
@@ -1,0 +1,1 @@
+uid://ckgoks6a0otl3

--- a/scenes/overlays/outpost/ContractSelectOverlay.tscn
+++ b/scenes/overlays/outpost/ContractSelectOverlay.tscn
@@ -1,0 +1,126 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Theme" uid="uid://2us73xfo2hnd" path="res://assets/style/DefaultTheme.tres" id="1_theme"]
+[ext_resource type="Script" path="res://scenes/overlays/outpost/ContractSelectOverlay.cs" id="2_script"]
+[ext_resource type="Script" uid="uid://b5nexivgcopri" path="res://core/ui/CloseOverlay.cs" id="3_close"]
+
+[node name="ContractSelectOverlay" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_theme")
+script = ExtResource("2_script")
+
+[node name="Panel" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.39308554, 0.3930855, 0.39308548, 1)
+
+[node name="Content" type="HBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 32.0
+offset_top = 96.0
+offset_right = -32.0
+offset_bottom = -32.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 24
+
+[node name="ContractPanel" type="PanelContainer" parent="Content"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="MarginContainer" type="MarginContainer" parent="Content/ContractPanel"]
+layout_mode = 2
+theme_override_constants/margin_left = 16
+theme_override_constants/margin_top = 16
+theme_override_constants/margin_right = 16
+theme_override_constants/margin_bottom = 16
+
+[node name="ContractLayout" type="VBoxContainer" parent="Content/ContractPanel/MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 12
+
+[node name="Title" type="Label" parent="Content/ContractPanel/MarginContainer/ContractLayout"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 32
+text = "Available Contracts"
+horizontal_alignment = 1
+
+[node name="EmptyLabel" type="Label" parent="Content/ContractPanel/MarginContainer/ContractLayout"]
+layout_mode = 2
+text = "No contracts available."
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="ContractList" type="VBoxContainer" parent="Content/ContractPanel/MarginContainer/ContractLayout"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 12
+
+[node name="PreviewPanel" type="PanelContainer" parent="Content"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="MarginContainer" type="MarginContainer" parent="Content/PreviewPanel"]
+layout_mode = 2
+theme_override_constants/margin_left = 24
+theme_override_constants/margin_top = 24
+theme_override_constants/margin_right = 24
+theme_override_constants/margin_bottom = 24
+
+[node name="PreviewLayout" type="VBoxContainer" parent="Content/PreviewPanel/MarginContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 16
+
+[node name="Title" type="Label" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 36
+text = "Choose Contract"
+
+[node name="PreviewDetails" type="Label" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
+layout_mode = 2
+size_flags_vertical = 3
+text = "Select one of the available contracts to continue the run."
+autowrap_mode = 3
+
+[node name="ChooseButton" type="Button" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
+custom_minimum_size = Vector2(0, 56)
+layout_mode = 2
+text = "Accept Contract"
+
+[node name="CloseOverlay" type="Button" parent="." node_paths=PackedStringArray("CloseTarget")]
+custom_minimum_size = Vector2(56, 56)
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -80.0
+offset_top = 24.0
+offset_right = -24.0
+offset_bottom = 80.0
+grow_horizontal = 0
+modulate = Color(1, 0.15, 0.15, 1)
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_colors/font_hover_color = Color(1, 1, 1, 1)
+theme_override_colors/font_pressed_color = Color(1, 1, 1, 1)
+text = "X"
+script = ExtResource("3_close")
+CloseTarget = NodePath("..")
+CloseAllOverlayChildren = true
+metadata/_custom_type_script = "uid://b5nexivgcopri"

--- a/scenes/overlays/outpost/ContractSelectOverlay.tscn
+++ b/scenes/overlays/outpost/ContractSelectOverlay.tscn
@@ -55,12 +55,12 @@ theme_override_constants/separation = 12
 [node name="Title" type="Label" parent="Content/ContractPanel/MarginContainer/ContractLayout"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-text = "Available Contracts"
+text = "Available Paths"
 horizontal_alignment = 1
 
 [node name="EmptyLabel" type="Label" parent="Content/ContractPanel/MarginContainer/ContractLayout"]
 layout_mode = 2
-text = "No contracts available."
+text = "No paths available."
 horizontal_alignment = 1
 vertical_alignment = 1
 
@@ -91,18 +91,18 @@ theme_override_constants/separation = 16
 [node name="Title" type="Label" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 36
-text = "Choose Contract"
+text = "Choose Path"
 
 [node name="PreviewDetails" type="Label" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
 layout_mode = 2
 size_flags_vertical = 3
-text = "Select one of the available contracts to continue the run."
+text = "Select one of the available paths to continue the run."
 autowrap_mode = 3
 
 [node name="ChooseButton" type="Button" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
 custom_minimum_size = Vector2(0, 56)
 layout_mode = 2
-text = "Accept Contract"
+text = "Accept Path"
 
 [node name="CloseOverlay" type="Button" parent="." node_paths=PackedStringArray("CloseTarget")]
 custom_minimum_size = Vector2(56, 56)


### PR DESCRIPTION
## Summary
- add a start menu desktop notice through `GlobalOverlay` when first-run tips are enabled on non-mobile devices
- add outpost contract path selection with persistent `ContractChooseData`, a dedicated contract select overlay, and biome-based progression weighting
- simplify contracts to biome-only progression while tracking contracts completed within the current biome