### PR TITLE
add contract path start action

### DIFF
--- a/core/items/ItemUsable.cs.uid
+++ b/core/items/ItemUsable.cs.uid
@@ -1,0 +1,1 @@
+uid://diwyvjwj54luy

--- a/core/items/actions/ActionContext.cs.uid
+++ b/core/items/actions/ActionContext.cs.uid
@@ -1,0 +1,1 @@
+uid://djnwd6v0v03ci

--- a/core/items/actions/PlayerAction.cs.uid
+++ b/core/items/actions/PlayerAction.cs.uid
@@ -1,0 +1,1 @@
+uid://dmyfvcjhf2o0e

--- a/scenes/components/outpost/BuildingData.cs
+++ b/scenes/components/outpost/BuildingData.cs
@@ -50,22 +50,27 @@ public partial class BuildingData : Resource {
 			if (buttonData == null)
 				continue;
 
-			bottomUi.AddChild(CreateButton(buttonData));
+			bottomUi.AddChild(CreateButton(buttonData, overlay));
 		}
 	}
 
-	private Button CreateButton(BuildingOverlayButtonData buttonData) {
-		var button = new Button {
-			CustomMinimumSize = new Vector2(80, 80),
-			SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
-			Text = buttonData.LabelName,
-			Icon = LoadIcon(buttonData.IconPath),
-			IconAlignment = HorizontalAlignment.Center,
-			VerticalIconAlignment = VerticalAlignment.Top,
-			ExpandIcon = true,
-		};
+	private Button CreateButton(BuildingOverlayButtonData buttonData, BuildingOverlay buildingOverlay) {
+		var button = buttonData.SceneToLoad == null
+			? new Button()
+			: new ChangeOverlayScene { SceneToLoad = buttonData.SceneToLoad };
 
-		button.Pressed += () => OpenPathController(buttonData);
+		button.CustomMinimumSize = new Vector2(80, 80);
+		button.SizeFlagsHorizontal = Control.SizeFlags.ExpandFill;
+		button.Text = buttonData.LabelName;
+		button.Icon = LoadIcon(buttonData.IconPath);
+		button.IconAlignment = HorizontalAlignment.Center;
+		button.VerticalIconAlignment = VerticalAlignment.Top;
+		button.ExpandIcon = true;
+		button.Disabled = buttonData.RequiresCurrentContract && SaveNode.Get()?.RunData?.CurrentContract == null;
+
+		if (buttonData.PathController != null)
+			button.Pressed += () => OpenPathController(buttonData, buildingOverlay);
+
 		return button;
 	}
 
@@ -76,7 +81,7 @@ public partial class BuildingData : Resource {
 		return ResourceLoader.Load<Texture2D>(iconPath) ?? _fallbackIcon;
 	}
 
-	private void OpenPathController(BuildingOverlayButtonData buttonData) {
+	private void OpenPathController(BuildingOverlayButtonData buttonData, BuildingOverlay buildingOverlay) {
 		if (buttonData.PathController == null) {
 			GD.PushWarning($"Building overlay button '{buttonData.LabelName}' has no path controller configured.");
 			return;
@@ -85,6 +90,8 @@ public partial class BuildingData : Resource {
 		var overlay = buttonData.PathController.Instantiate();
 		if (overlay is StorefrontOverlay storefrontOverlay)
 			storefrontOverlay.Update(this);
+
+		overlay.TreeExited += () => Generate(buildingOverlay);
 
 		GlobalOverlay.Get()?.AddChild(overlay);
 	}

--- a/scenes/components/outpost/contract_building_data.tres
+++ b/scenes/components/outpost/contract_building_data.tres
@@ -1,17 +1,24 @@
-[gd_resource type="Resource" script_class="BuildingData" load_steps=3 format=3 uid="uid://dc5yw0wdd4tyc"]
+[gd_resource type="Resource" script_class="BuildingData" load_steps=4 format=3 uid="uid://dc5yw0wdd4tyc"]
 
 [ext_resource type="Script" uid="uid://enkabhmf46kb" path="res://scenes/overlays/building/BuildingOverlayButtonData.cs" id="1_2fvkw"]
 [ext_resource type="Script" uid="uid://cd5blmxgvl3oe" path="res://scenes/components/outpost/BuildingData.cs" id="1_contract"]
 [ext_resource type="PackedScene" path="res://scenes/overlays/outpost/ContractSelectOverlay.tscn" id="2_contract_select"]
+[ext_resource type="PackedScene" uid="uid://1lffmaipx3ky" path="res://scenes/debug/player_test_world.tscn" id="3_path_scene"]
 
 [sub_resource type="Resource" id="Resource_choose_contract"]
 script = ExtResource("1_2fvkw")
 LabelName = "Choose Path"
 PathController = ExtResource("2_contract_select")
 
+[sub_resource type="Resource" id="Resource_begin_path"]
+script = ExtResource("1_2fvkw")
+LabelName = "Begin Path"
+SceneToLoad = ExtResource("3_path_scene")
+RequiresCurrentContract = true
+
 [resource]
 script = ExtResource("1_contract")
 LabelName = "Path"
 Description = "Choose the next path for this run."
 OwnerText = "Paths are opening. Pick carefully; each choice shapes where this run goes next."
-OverlayButtons = Array[Resource]([SubResource("Resource_choose_contract")])
+OverlayButtons = Array[Resource]([SubResource("Resource_choose_contract"), SubResource("Resource_begin_path")])

--- a/scenes/overlays/building/BuildingOverlayButtonData.cs
+++ b/scenes/overlays/building/BuildingOverlayButtonData.cs
@@ -7,4 +7,6 @@ public partial class BuildingOverlayButtonData : Resource {
 
 	[Export] public string LabelName { get; set; }
 	[Export] public PackedScene PathController { get; set; }
+	[Export] public PackedScene SceneToLoad { get; set; }
+	[Export] public bool RequiresCurrentContract { get; set; }
 }

--- a/scenes/overlays/outpost/ContractSelectOverlay.cs
+++ b/scenes/overlays/outpost/ContractSelectOverlay.cs
@@ -62,7 +62,6 @@ public partial class ContractSelectOverlay : Control {
 			_contractList.AddChild(CreateContractButton(contract));
 		}
 
-		_selectedContract ??= contracts[0];
 	}
 
 	private Button CreateContractButton(Contract contract) {

--- a/scenes/overlays/outpost/ContractSelectOverlay.tscn
+++ b/scenes/overlays/outpost/ContractSelectOverlay.tscn
@@ -102,7 +102,8 @@ autowrap_mode = 3
 [node name="ChooseButton" type="Button" parent="Content/PreviewPanel/MarginContainer/PreviewLayout"]
 custom_minimum_size = Vector2(0, 56)
 layout_mode = 2
-text = "Accept Path"
+disabled = true
+text = "Select"
 
 [node name="CloseOverlay" type="Button" parent="." node_paths=PackedStringArray("CloseTarget")]
 custom_minimum_size = Vector2(56, 56)


### PR DESCRIPTION
## Summary
- Adds a second contract building action for beginning the selected path.
- Keeps path selection in the contract overlay while enabling the start action only after a contract exists.
- Extends building overlay button data to support scene-changing actions and contract-gated buttons.

## Verification
- dotnet build